### PR TITLE
Update 80-20-rail.kcl

### DIFF
--- a/80-20-rail.kcl
+++ b/80-20-rail.kcl
@@ -1,68 +1,200 @@
 // 80/20 Rail
-// An 80/20 extruded aluminum linear rail. T-slot profile adjustable by rail height, length, and base position
+// An 80/20 extruded aluminum linear rail. T-slot profile adjustable by profile height, rail length, and origin position
 
 
 // define function
-fn rail8020 = (originStart, railHeight, height) => {
-  const plane001 = {
-    plane: {
-      origin: [originStart[0], originStart[1], 0],
-      xAxis: [1.0, 0.0, 0.0],
-      yAxis: [0.0, 1.0, 0.0],
-      zAxis: [0.0, 0.0, 1.0]
-    }
-  }
-
-  // sketch rail center
-  const sketch001 = startSketchOn(plane001)
-    |> startProfileAt([0.322 * railHeight, 0.322 * railHeight], %)
-    |> angledLine([0, 0.356 * railHeight], %, $rectangleSegmentA001)
-    |> angledLine([
-         segAng(rectangleSegmentA001) + 90,
-         0.356 * railHeight
-       ], %, $rectangleSegmentB001)
-    |> angledLine([
-         segAng(rectangleSegmentA001),
-         -segLen(rectangleSegmentA001)
-       ], %, $rectangleSegmentC001)
-    |> lineTo([profileStartX(%), profileStartY(%)], %)
-    |> close(%)
-    |> hole(circle([.5 * railHeight, .5 * railHeight], .205 * railHeight / 2, %), %)
-    |> extrude(height, %)
-
-  // sketch T-slot corner
-  const sketch002 = startSketchOn(plane001)
-    |> startProfileAt([0, 0.372 * railHeight], %)
-    |> yLine(-0.372 * railHeight, %)
-    |> xLine(0.372 * railHeight, %)
-    |> yLine(0.087 * railHeight, %)
-    |> xLine(-0.2 * railHeight, %)
-    |> angledLineToY({ angle: 45, to: 0.322 * railHeight }, %)
-    |> angledLineToX({ angle: 180, to: 0.322 * railHeight }, %)
-    |> yLine(0.1 * railHeight, %)
-    |> angledLineToX({ angle: -135, to: 0.087 * railHeight }, %)
-    |> angledLineToY({ angle: 90, to: 0.372 * railHeight }, %)
-    |> lineTo([profileStartX(%), profileStartY(%)], %)
-    |> close(%)
-  const pattern001 = extrude(height, sketch002)
-  
-  // circular pattern 3D T-slot corner feature
-    |> patternCircular3d({
-         axis: [0, 0, 1],
-         center: [
-           railHeight / 2 + originStart[0],
-           railHeight / 2 + originStart[1],
-           0
-         ],
-         repetitions: 3,
-         arcDegrees: 360,
-         rotateDuplicates: true
+fn rail8020 = (originStart, railHeight, railLength) => {
+  // Sketch Side 1 of Profile
+  const sketch001 = startSketchOn('-XZ')
+    |> startProfileAt([
+         originStart[0],
+         0.1 * railHeight + originStart[1]
+       ], %)
+    |> arc({
+         angleStart: 180,
+         angleEnd: 270,
+         radius: 0.1 * railHeight
        }, %)
-  return pattern001
+    |> arc({
+         angleStart: 180,
+         angleEnd: 0,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> xLine(0.1 * railHeight, %)
+    |> arc({
+         angleStart: 180,
+         angleEnd: 0,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> xLine(0.06 * railHeight, %, $edge1)
+    |> yLine(0.087 * railHeight, %, $edge2)
+    |> xLine(-0.183 * railHeight, %, $edge3)
+    |> angledLineToY({
+         angle: 45,
+         to: (1 - 0.356) / 2 * railHeight + originStart[1]
+       }, %, $edge4)
+    |> xLine(0.232 * railHeight, %, $edge5)
+    |> angledLineToY({
+         angle: -45,
+         to: 0.087 * railHeight + originStart[1]
+       }, %, $edge6)
+    |> xLine(-0.183 * railHeight, %, $edge7)
+    |> yLine(-0.087 * railHeight, %, $edge8)
+    |> xLine(0.06 * railHeight, %)
+    |> arc({
+         angleStart: 180,
+         angleEnd: 0,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> xLine(0.1 * railHeight, %)
+    |> arc({
+         angleStart: 180,
+         angleEnd: 0,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> arc({
+         angleStart: -90,
+         angleEnd: 0,
+         radius: 0.1 * railHeight
+       }, %)
+
+    // Sketch Side 2 of Profile
+    |> arc({
+         angleStart: 270,
+         angleEnd: 90,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> yLine(0.1 * railHeight, %)
+    |> arc({
+         angleStart: 270,
+         angleEnd: 90,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> yLine(0.06 * railHeight, %, $edge9)
+    |> xLine(-0.087 * railHeight, %, $edge10)
+    |> yLine(-0.183 * railHeight, %, $edge11) // edge11
+    |> angledLineToX({
+         angle: 135,
+         to: ((1 - 0.356) / 2 + 0.356) * railHeight + originStart[0]
+       }, %, $edge12) // edge12
+    |> yLine(0.232 * railHeight, %, $edge13) // 13
+    |> angledLineToX({
+         angle: 45,
+         to: (1 - 0.087) * railHeight + originStart[0]
+       }, %, $edge14) // 14
+    |> yLine(-0.183 * railHeight, %, $edge15) // 15
+    |> xLine(0.087 * railHeight, %, $edge16)
+    |> yLine(0.06 * railHeight, %)
+    |> arc({
+         angleStart: 270,
+         angleEnd: 90,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> yLine(0.1 * railHeight, %)
+    |> arc({
+         angleStart: 270,
+         angleEnd: 90,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+
+    // Sketch Side 3 of Profile
+    |> arc({
+         angleStart: 0,
+         angleEnd: 90,
+         radius: 0.1 * railHeight
+       }, %)
+    |> arc({
+         angleStart: 0,
+         angleEnd: -180,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> xLine(-0.1 * railHeight, %)
+    |> arc({
+         angleStart: 0,
+         angleEnd: -180,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> xLine(-0.06 * railHeight, %, $edge17)
+    |> yLine(-0.087 * railHeight, %, $edge18)
+    |> xLine(0.183 * railHeight, %, $edge19)
+    |> angledLineToY({
+         angle: 45,
+         to: ((1 - 0.356) / 2 + 0.356) * railHeight + originStart[1]
+       }, %, $edge20)
+    |> xLine(-0.232 * railHeight, %, $edge21)
+    |> angledLineToY({
+         angle: 135,
+         to: (1 - 0.087) * railHeight + originStart[1]
+       }, %, $edge22)
+    |> xLine(0.183 * railHeight, %, $edge23)
+    |> yLine(0.087 * railHeight, %, $edge24)
+    |> xLine(-0.06 * railHeight, %)
+    |> arc({
+         angleStart: 0,
+         angleEnd: -180,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> xLine(-0.1 * railHeight, %)
+    |> arc({
+         angleStart: 0,
+         angleEnd: -180,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> arc({
+         angleStart: 90,
+         angleEnd: 180,
+         radius: 0.1 * railHeight
+       }, %)
+
+    // Sketch Side 4 of Profile
+    |> arc({
+         angleStart: 90,
+         angleEnd: -90,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> yLine(-0.1 * railHeight, %)
+    |> arc({
+         angleStart: 90,
+         angleEnd: -90,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> yLine(-0.06 * railHeight, %, $edge25)
+    |> xLine(0.087 * railHeight, %, $edge26)
+    |> yLine(0.183 * railHeight, %, $edge27)
+    |> angledLineToX({
+         angle: 135,
+         to: (1 - 0.356) / 2 * railHeight + originStart[0]
+       }, %, $edge28)
+    |> yLine(-0.232 * railHeight, %, $edge29)
+    |> angledLineToX({
+         angle: 45,
+         to: 0.087 * railHeight + originStart[0]
+       }, %, $edge30)
+    |> yLine(0.183 * railHeight, %, $edge31)
+    |> xLine(-0.087 * railHeight, %, $edge32)
+    |> yLine(-0.06 * railHeight, %)
+    |> arc({
+         angleStart: 90,
+         angleEnd: -90,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> yLine(-0.1 * railHeight, %)
+    |> arc({
+         angleStart: 90,
+         angleEnd: -90,
+         radius: 0.072 / 4 * railHeight
+       }, %)
+    |> lineTo([profileStartX(%), profileStartY(%)], %)
+    |> close(%)
+
+    // Sketch Center Hole of Profile
+    |> hole(circle([
+         .5 * railHeight + originStart[0],
+         .5 * railHeight + originStart[1]
+       ], .205 * railHeight / 2, %), %)
+    |> extrude(railLength, %)
+  return sketch001
 }
 
-// generate 4 adjustable rails
-rail8020([0, 0], 1.5, 50)
-rail8020([0, 20], 1, 60)
-rail8020([30, 0], 1, 70)
-rail8020([30, 20], 1, 80)
+// generate one adjustable rail of 80/20
+rail8020([0, 0], 1.5, 48)


### PR DESCRIPTION
Changing the 80/20 rail sample file to only include one rail. Having 4 rails in the base file had undesired impacts on Text-to-cad output. Prompting "one rail of 80/20" would generate one rail, but prompting "a rail of 80/20" would create four. "Two rails of 80/20" returned two rails with different heights.

Changing the base plane of the extrusion so that the rails lay flat on the ground rather than stand on end to avoid confusion when prompting. The height of the rail is the height of the profile. The length of the rail is the overall length.

Changing the profile to be a single sketch and adding detail so the model looks better.

Having some trouble with fillets so leaving them out for now