### PR TITLE
Update these to match new engine method

### DIFF
--- a/80-20-rail/80-20-rail.kcl
+++ b/80-20-rail/80-20-rail.kcl
@@ -184,7 +184,6 @@ fn rail8020 = (originStart, railHeight, railLength) => {
          angleEnd: -90,
          radius: 0.072 / 4 * railHeight
        }, %)
-    |> lineTo([profileStartX(%), profileStartY(%)], %)
     |> close(%)
 
     // Sketch Center Hole of Profile

--- a/bracket/bracket.kcl
+++ b/bracket/bracket.kcl
@@ -28,14 +28,14 @@ const bracketLeg1Sketch = startSketchOn('XY')
   |> hole(circle([leg1Length-1.5, width-1], mountingHoleDiameter/2, %), %)
   |> hole(circle([1, width-1], mountingHoleDiameter/2, %), %)
   |> hole(circle([leg1Length-1.5, 1], mountingHoleDiameter/2, %), %)
-  
+
 // Extrude the leg 2 bracket sketch
 const bracketLeg1Extrude = extrude(thickness, bracketLeg1Sketch)
   |> fillet({
     radius: extFilletRadius,
     tags: [
-      getPreviousAdjacentEdge(fillet1),
-      getPreviousAdjacentEdge(fillet2)
+      getNextAdjacentEdge(fillet1),
+      getNextAdjacentEdge(fillet2)
     ],
   }, %)
 
@@ -55,7 +55,7 @@ const filletSketch = startSketchOn('XZ')
     radius: filletRadius,
   }, %)
 
-// Sketch the bend  
+// Sketch the bend
 const filletExtrude = extrude(-width, filletSketch)
 
 // Create a custom plane for the leg that sits on the wall
@@ -83,7 +83,7 @@ const bracketLeg2Extrude = extrude(-thickness, bracketLeg2Sketch)
   |> fillet({
     radius: extFilletRadius,
     tags: [
-      getPreviousAdjacentEdge(fillet3),
-      getPreviousAdjacentEdge(fillet4)
+      getNextAdjacentEdge(fillet3),
+      getNextAdjacentEdge(fillet4)
     ],
   }, %)

--- a/focusrite-scarlett-mounting-bracket/focusrite-scarlett-mounting-bracket.kcl
+++ b/focusrite-scarlett-mounting-bracket/focusrite-scarlett-mounting-bracket.kcl
@@ -55,10 +55,10 @@ const bracketBody = bs
   |> fillet({
        radius: radius,
        tags: [
-         getNextAdjacentEdge(bs.tags.edge7),
-         getNextAdjacentEdge(bs.tags.edge2),
-         getNextAdjacentEdge(bs.tags.edge3),
-         getNextAdjacentEdge(bs.tags.edge6)
+         getPreviousAdjacentEdge(bs.tags.edge7),
+         getPreviousAdjacentEdge(bs.tags.edge2),
+         getPreviousAdjacentEdge(bs.tags.edge3),
+         getPreviousAdjacentEdge(bs.tags.edge6)
        ]
      }, %)
 

--- a/focusrite-scarlett-mounting-bracket/focusrite-scarlett-mounting-bracket.kcl
+++ b/focusrite-scarlett-mounting-bracket/focusrite-scarlett-mounting-bracket.kcl
@@ -87,8 +87,8 @@ const tabsR = startSketchOn(tabPlane)
   |> fillet({
        radius: holeDiam / 2,
        tags: [
-         getNextAdjacentEdge(edge12),
-         getNextAdjacentEdge(edge13)
+         getNextAdjacentEdge(edge11),
+         getNextAdjacentEdge(edge12)
        ]
      }, %)
   |> patternLinear3d({


### PR DESCRIPTION
Not to merge until after BOTH
https://github.com/KittyCAD/engine/pull/2518/files
and 
associated modeling app PR are merged

I triaged all occurences of getNext/getPrev to ensure they follow the path.  Double check me on these, but all should be consistent to the path direction now.
