### PR TITLE
Add a generated manifest.json

### DIFF
--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -1,0 +1,45 @@
+name: Generate Manifest
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # Allows manual triggering from the Actions tab
+
+jobs:
+  generate-manifest:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Set up Node.js
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'  # Specify the Node.js version you need
+
+      # Install dependencies (if any are needed)
+      - name: Install dependencies
+        run: npm install
+
+      # Run the script to generate the manifest.json
+      - name: Run manifest generation script
+        run: node generateManifest.js
+
+      # Check if the manifest.json has changed
+      - name: Check for changes
+        run: |
+          git diff --exit-code ./manifest.json || echo "Changes detected"
+
+      # Stage and commit the changes if any were made
+      - name: Commit and push changes
+        if: ${{ success() && (steps.Check_for_changes.outputs.changed == 'true') }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add ./manifest.json
+          git commit -m "Update manifest.json"
+          git push

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -17,13 +17,9 @@ jobs:
 
       # Set up Node.js
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'  # Specify the Node.js version you need
-
-      # Install dependencies (if any are needed)
-      - name: Install dependencies
-        run: npm install
+          node-version: '18'  # Specify the Node.js version you need
 
       # Run the script to generate the manifest.json
       - name: Run manifest generation script

--- a/generate-manifest.js
+++ b/generate-manifest.js
@@ -1,0 +1,58 @@
+const fs = require("fs");
+const path = require("path");
+
+const FILE_EXTENSION = ".kcl";
+const MANIFEST_FILE = "manifest.json";
+const COMMENT_PREFIX = "//";
+
+// Function to read and parse .kcl files
+const getKclMetadata = (filePath) => {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+
+  if (lines.length < 2) {
+    return null;
+  }
+
+  const title = lines[0].replace(COMMENT_PREFIX, "").trim();
+  const description = lines[1].replace(COMMENT_PREFIX, "").trim();
+
+  return {
+    file: path.basename(filePath),
+    title,
+    description,
+  };
+};
+
+// Function to scan the directory and generate the manifest.json
+const generateManifest = (dir) => {
+  const projectDirectories = fs.readdirSync(dir);
+  const manifest = [];
+
+  projectDirectories.forEach((file) => {
+    const filePath = path.join(dir, file);
+    const stattedDir = fs.statSync(filePath);
+    if (stattedDir.isDirectory()) {
+      const files = fs
+        .readdirSync(filePath)
+        .filter((f) => f.endsWith(FILE_EXTENSION));
+      if (files.length === 0) {
+        return;
+      }
+      const metadata = getKclMetadata(path.join(filePath, files[0]));
+      if (metadata) {
+        manifest.push(metadata);
+      }
+    }
+  });
+
+  // Write the manifest.json
+  const outputPath = path.join(dir, MANIFEST_FILE);
+  fs.writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
+  console.log(`Manifest of ${manifest.length} items written to ${outputPath}`);
+};
+
+// Run the script
+console.log(`Generating ${MANIFEST_FILE}...`);
+const projectDir = path.resolve(__dirname); // Set project root directory
+generateManifest(projectDir);

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,152 @@
+[
+  {
+    "file": "80-20-rail.kcl",
+    "title": "80/20 Rail",
+    "description": "An 80/20 extruded aluminum linear rail. T-slot profile adjustable by profile height, rail length, and origin position"
+  },
+  {
+    "file": "a-parametric-bearing-pillow-block.kcl",
+    "title": "A Parametric Bearing Pillow Block",
+    "description": "A bearing pillow block, also known as a plummer block or pillow block bearing, is a pedestal used to provide support for a rotating shaft with the help of compatible bearings and various accessories. Housing a bearing, the pillow block provides a secure and stable foundation that allows the shaft to rotate smoothly within its machinery setup. These components are essential in a wide range of mechanical systems and machinery, playing a key role in reducing friction and supporting radial and axial loads."
+  },
+  {
+    "file": "ball-bearing.kcl",
+    "title": "Ball Bearing",
+    "description": "A ball bearing is a type of rolling-element bearing that uses balls to maintain the separation between the bearing races. The primary purpose of a ball bearing is to reduce rotational friction and support radial and axial loads."
+  },
+  {
+    "file": "bracket.kcl",
+    "title": "Shelf Bracket",
+    "description": "This is a bracket that holds a shelf. It is made of aluminum and is designed to hold a force of 300 lbs. The bracket is 6 inches wide and the force is applied at the end of the shelf, 12 inches from the wall. The bracket has a factor of safety of 1.2. The legs of the bracket are 5 inches and 2 inches long. The thickness of the bracket is calculated from the constraints provided."
+  },
+  {
+    "file": "brake-caliper.kcl",
+    "title": "Brake Caliper",
+    "description": "Brake calipers are used to squeeze the brake pads against the rotor, causing larger and larger amounts of friction depending on how hard the brakes are pressed."
+  },
+  {
+    "file": "car-wheel.kcl",
+    "title": "Car Wheel",
+    "description": "A sports car wheel with a circular lug pattern and spokes."
+  },
+  {
+    "file": "car-wheel-assembly.kcl",
+    "title": "Car Wheel Assembly",
+    "description": "A car wheel assembly with a rotor, tire, and lug nuts."
+  },
+  {
+    "file": "enclosure.kcl",
+    "title": "Enclosure",
+    "description": "An enclosure body and sealing lid for storing items"
+  },
+  {
+    "file": "flange-with-patterns.kcl",
+    "title": "Flange",
+    "description": "A flange is a flat rim, collar, or rib, typically forged or cast, that is used to strengthen an object, guide it, or attach it to another object. Flanges are known for their use in various applications, including piping, plumbing, and mechanical engineering, among others."
+  },
+  {
+    "file": "flange-xy.kcl",
+    "title": "Flange with XY coordinates",
+    "description": "A flange is a flat rim, collar, or rib, typically forged or cast, that is used to strengthen an object, guide it, or attach it to another object. Flanges are known for their use in various applications, including piping, plumbing, and mechanical engineering, among others."
+  },
+  {
+    "file": "focusrite-scarlett-mounting-bracket.kcl",
+    "title": "A mounting bracket for the Focusrite Scarlett Solo audio interface",
+    "description": "This is a bracket that holds an audio device underneath a desk or shelf. The audio device has dimensions of 144mm wide, 80mm length and 45mm depth with fillets of 6mm. This mounting bracket is designed to be 3D printed with PLA material"
+  },
+  {
+    "file": "french-press.kcl",
+    "title": "French Press",
+    "description": "A french press immersion coffee maker"
+  },
+  {
+    "file": "gear.kcl",
+    "title": "Gear",
+    "description": "A rotating machine part having cut teeth or, in the case of a cogwheel, inserted teeth (called cogs), which mesh with another toothed part to transmit torque. Geared devices can change the speed, torque, and direction of a power source. The two elements that define a gear are its circular shape and the teeth that are integrated into its outer edge, which are designed to fit into the teeth of another gear."
+  },
+  {
+    "file": "gear-rack.kcl",
+    "title": "100mm Gear Rack",
+    "description": "A flat bar or rail that is engraved with teeth along its length. These teeth are designed to mesh with the teeth of a gear, known as a pinion. When the pinion, a small cylindrical gear, rotates, its teeth engage with the teeth on the rack, causing the rack to move linearly. Conversely, linear motion applied to the rack will cause the pinion to rotate."
+  },
+  {
+    "file": "hex-nut.kcl",
+    "title": "Hex nut",
+    "description": "A hex nut is a type of fastener with a threaded hole and a hexagonal outer shape, used in a wide variety of applications to secure parts together. The hexagonal shape allows for a greater torque to be applied with wrenches or tools, making it one of the most common nut types in hardware."
+  },
+  {
+    "file": "kitt.kcl",
+    "title": "Kitt",
+    "description": "The beloved KittyCAD mascot in a voxelized style."
+  },
+  {
+    "file": "lego.kcl",
+    "title": "Lego Brick",
+    "description": "A standard Lego brick. This is a small, plastic construction block toy that can be interlocked with other blocks to build various structures, models, and figures. There are a lot of hacks used in this code."
+  },
+  {
+    "file": "lug-nut.kcl",
+    "title": "Lug Nut",
+    "description": "lug Nuts are essential components used to create secure connections, whether for electrical purposes, like terminating wires or grounding, or for mechanical purposes, such as providing mounting points or reinforcing structural joints."
+  },
+  {
+    "file": "mounting-plate.kcl",
+    "title": "Mounting Plate",
+    "description": "A flat piece of material, often metal or plastic, that serves as a support or base for attaching, securing, or mounting various types of equipment, devices, or components."
+  },
+  {
+    "file": "multi-axis-robot.kcl",
+    "title": "Robot Arm",
+    "description": "A 4 axis robotic arm for industrial use. These machines can be used for assembly, packaging, organization of goods, and quality inspection processes"
+  },
+  {
+    "file": "pipe.kcl",
+    "title": "Pipe",
+    "description": "A tubular section or hollow cylinder, usually but not necessarily of circular cross-section, used mainly to convey substances that can flow."
+  },
+  {
+    "file": "pipe-flange-assembly.kcl",
+    "title": "Pipe and Flange Assembly",
+    "description": "A crucial component in various piping systems, designed to facilitate the connection, disconnection, and access to piping for inspection, cleaning, and modifications. This assembly combines pipes (long cylindrical conduits) with flanges (plate-like fittings) to create a secure yet detachable joint."
+  },
+  {
+    "file": "poopy-shoe.kcl",
+    "title": "Poopy Shoe",
+    "description": "poop shute for bambu labs printer - optimized for printing."
+  },
+  {
+    "file": "router-template-cross-bar.kcl",
+    "title": "Router template for a cross bar",
+    "description": "A guide for routing a notch into a cross bar."
+  },
+  {
+    "file": "router-template-slate.kcl",
+    "title": "Router template for a slate",
+    "description": "A guide for routing a slate for a cross bar."
+  },
+  {
+    "file": "sheet-metal-bracket.kcl",
+    "title": "Sheet Metal Bracket",
+    "description": "A component typically made from flat sheet metal through various manufacturing processes such as bending, punching, cutting, and forming. These brackets are used to support, attach, or mount other hardware components, often providing a structural or functional base for assembly."
+  },
+  {
+    "file": "socket-head-cap-screw.kcl",
+    "title": "Socket Head Cap Screw",
+    "description": "This is for a #10-24 screw that is 1.00 inches long. A socket head cap screw is a type of fastener that is widely used in a variety of applications requiring a high strength fastening solution. It is characterized by its cylindrical head and internal hexagonal drive, which allows for tightening with an Allen wrench or hex key."
+  },
+  {
+    "file": "tire.kcl",
+    "title": "Tire",
+    "description": "A tire is a critical component of a vehicle that provides the necessary traction and grip between the car and the road. It supports the vehicle's weight and absorbs shocks from road irregularities."
+  },
+  {
+    "file": "washer.kcl",
+    "title": "Washer",
+    "description": "A small, typically disk-shaped component with a hole in the middle, used in a wide range of applications, primarily in conjunction with fasteners like bolts and screws. Washers distribute the load of a fastener across a broader area. This is especially important when the fastening surface is soft or uneven, as it helps to prevent damage to the surface and ensures the load is evenly distributed, reducing the risk of the fastener becoming loose over time."
+  },
+  {
+    "file": "wheel-rotor.kcl",
+    "title": "Wheel rotor",
+    "description": "A component of a disc brake system. It provides a surface for brake pads to press against, generating the friction needed to slow or stop the vehicle."
+  }
+]


### PR DESCRIPTION
Adds a manifest.json file that contains the filename, title, and description of each example (which follow conventions according to the README). This will be useful for applications that want to use the samples but only fetch all their contents as needed, such as the feature I'm building into Zoo Modeling App with [this PR](https://github.com/KittyCAD/modeling-app/pull/3912).

Also adds an accompanying GitHub Action that runs whenever samples are added or removed.

I'll add @jgomez720 and @greg-kcio as reviewers here too, because I don't want to break anything else that might be making assumptions about the shape of this repo, because I'm adding a `.js` and `.json` file to its root. If this isn't the best way to get this kind of manifest let me know.