### PR TITLE
Run the node script relative to the repo root, don't specify a node version

### DIFF
--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -18,12 +18,10 @@ jobs:
       # Set up Node.js
       - name: Set up Node.js
         uses: actions/setup-node@v4
-        with:
-          node-version: '18'  # Specify the Node.js version you need
 
       # Run the script to generate the manifest.json
       - name: Run manifest generation script
-        run: node generateManifest.js
+        run: node ./generateManifest.js
 
       # Check if the manifest.json has changed
       - name: Check for changes


### PR DESCRIPTION
Trying to fix the GH Action's behavior.