### PR TITLE
Don't process KCL on push to main

### DIFF
--- a/.github/workflows/output-from-kcl-samples.yml
+++ b/.github/workflows/output-from-kcl-samples.yml
@@ -12,9 +12,6 @@ on:
             - .github/workflows/output-from-kcl-samples.yml
         branches:
             - main
-    push:
-        branches:
-            - main
     workflow_dispatch:
 
 jobs:

--- a/step/80-20-rail.step
+++ b/step/80-20-rail.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:11.377170441+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:18.785315435+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/a-parametric-bearing-pillow-block.step
+++ b/step/a-parametric-bearing-pillow-block.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:08.266263580+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:14.304695461+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/ball-bearing.step
+++ b/step/ball-bearing.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:08.842902103+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:15.760682700+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/bracket.step
+++ b/step/bracket.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:08.403332275+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:13.988026339+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/brake-caliper.step
+++ b/step/brake-caliper.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:07.999442948+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:14.620758027+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/car-wheel-assembly.step
+++ b/step/car-wheel-assembly.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:15.981301068+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:23.870641944+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/car-wheel.step
+++ b/step/car-wheel.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:12.982484172+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:20.751776387+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/dodecahedron.step
+++ b/step/dodecahedron.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:11.567584809+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:19.187554639+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/enclosure.step
+++ b/step/enclosure.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:14.401364029+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:23.191090152+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/flange-with-patterns.step
+++ b/step/flange-with-patterns.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:15.134115604+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:22.749776846+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/flange-xy.step
+++ b/step/flange-xy.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:17.932318443+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:26.279482716+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/focusrite-scarlett-mounting-bracket.step
+++ b/step/focusrite-scarlett-mounting-bracket.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:18.998183281+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:27.547932060+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/food-service-spatula.step
+++ b/step/food-service-spatula.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:18.336936971+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:28.742892698+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/french-press.step
+++ b/step/french-press.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:22.370655819+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:33.791297857+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/gear-rack.step
+++ b/step/gear-rack.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:23.954106815+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:34.575209932+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/gear.step
+++ b/step/gear.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:21.426353129+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:31.187395262+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/hex-nut.step
+++ b/step/hex-nut.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:22.635619338+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:33.013494039+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/kitt.step
+++ b/step/kitt.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:26.019328697+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:35.882430977+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/lego.step
+++ b/step/lego.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:28.288379502+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:39.135557907+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/lug-nut.step
+++ b/step/lug-nut.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:25.001002937+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:35.946069963+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/mounting-plate.step
+++ b/step/mounting-plate.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:27.470925969+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:38.449026995+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/multi-axis-robot.step
+++ b/step/multi-axis-robot.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:38.028392905+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:48.129334756+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/pipe-flange-assembly.step
+++ b/step/pipe-flange-assembly.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:32.440260570+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:45.285953007+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/pipe.step
+++ b/step/pipe.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:28.688250774+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:40.181352335+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/poopy-shoe.step
+++ b/step/poopy-shoe.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:31.680511099+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:42.770922511+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/router-template-cross-bar.step
+++ b/step/router-template-cross-bar.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:31.293153171+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:43.370181537+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/router-template-slate.step
+++ b/step/router-template-slate.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:33.990578709+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:44.713789390+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/sheet-metal-bracket.step
+++ b/step/sheet-metal-bracket.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:35.107368235+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:47.262224515+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/socket-head-cap-screw.step
+++ b/step/socket-head-cap-screw.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:34.549266205+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:46.316518893+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/tire.step
+++ b/step/tire.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:36.512675980+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:47.860327662+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/wall-e.step
+++ b/step/wall-e.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:51.316565932+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:54:07.376511574+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/washer.step
+++ b/step/washer.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:37.196545291+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:53:50.260530979+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;

--- a/step/wheel-rotor.step
+++ b/step/wheel-rotor.step
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((('zoo.dev export')), '2;1');
-FILE_NAME('dump.step', '2024-12-03T16:25:50.271301257+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
+FILE_NAME('dump.step', '2024-12-03T16:54:03.723419597+00:00', ('Author unknown'), ('Organization unknown'), 'zoo.dev beta', 'zoo.dev', 'Authorization unknown');
 FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_OF_MECHANICAL_PARTS_AND_ASSEMBLIES_MIM_LF'));
 ENDSEC;
 DATA;


### PR DESCRIPTION
Snapshotting and exporting all of the STEP files takes some time and already triggers when opening a PR, so we don't need to run it again when the PR is merged.