### PR TITLE
[WIP] Chicken coop

### DIFF
--- a/chicken-coop/assembly.kcl
+++ b/chicken-coop/assembly.kcl
@@ -1,0 +1,63 @@
+import coopFront from "coopFront.kcl"
+import coopRoof from "coopRoof.kcl"
+// import coopBack from "coopBack.kcl"
+import coopOutsideWall from "coopOutsideWall.kcl"
+// import coopRunWall from "coopRunWall.kcl"
+// import runEnd from "runEnd.kcl"
+// import runWallsAndRoof from "runWallsAndRoof.kcl"
+import nestingBox from "nestingBox.kcl"
+import foundation from "foundation.kcl"
+
+import variables from "vars.kcl"
+import pitchedStud, flatten, verticalStudGeo, studWithoutAngles from "studUtils.kcl"
+
+v = variables()
+runRafterCount = v.runRafterCount
+interRafterDistance = v.interRafterDistance
+runEndPlane = v.runEndPlane
+coopLength = v.coopLength
+runDoorWidth = v.runDoorWidth
+studWidth = v.studWidth
+studDepth = v.studDepth
+runRoofPitchR = v.runRoofPitchR
+runRoofPitch = v.runRoofPitch
+heightOfRunEndWall = v.heightOfRunEndWall
+studThicknessAtRunAngle = v.studThicknessAtRunAngle
+runPitchedStudLen = v.runPitchedStudLen
+runDoorHeight = v.runDoorHeight
+runHorzBraceHeight = v.runHorzBraceHeight
+studTallSideThicknessAtRunAngle = v.studTallSideThicknessAtRunAngle
+runSideEaveOverHang = v.runSideEaveOverHang
+rafterCommonZ = v.rafterCommonZ
+runRafterCommonHorizontalDistance = v.runRafterCommonHorizontalDistance
+ridgeWidth = v.ridgeWidth
+runRafterRatio = v.runRafterRatio
+frontRoofAngle = v.frontRoofAngle
+xCoordForRunHorzSupportFront = v.xCoordForRunHorzSupportFront
+xCoordForRunHorzSupportBack = v.xCoordForRunHorzSupportBack
+heightToNotchIntoRafters = v.heightToNotchIntoRafters
+nestingBoxDepth = v.nestingBoxDepth
+nestingRoofPitch = v.nestingRoofPitch
+nestingRoofPitchR = v.nestingRoofPitchR
+frontPlane = v.frontPlane
+coopStorageLength = v.coopStorageLength
+nestingBoxHeight = v.nestingBoxHeight
+sideEaveOverHang = v.sideEaveOverHang
+studTallSideThicknessAtAngle = v.studTallSideThicknessAtAngle
+angleFromRunRoofToCoopRoof = v.angleFromRunRoofToCoopRoof
+horizontalLengthAlongRunFromvalleyToTip = v.horizontalLengthAlongRunFromvalleyToTip
+coopWidth = v.coopWidth
+coopRoofPitchR = v.coopRoofPitchR
+coopRoofPitch = v.coopRoofPitch
+angleFromCoopRoofToRunRoof = v.angleFromCoopRoofToRunRoof
+
+coopFront(v.frontPlane)
+coopRoof(v.backPlane)
+// coopBack(v.backPlane)
+coopOutsideWall(v.outsideWallPlane)
+nestingBox()
+// coopRunWall(v.runWallPlane)
+// runEnd()
+// runWallsAndRoof(v.runWallPlane)
+foundation()
+

--- a/chicken-coop/coopBack.kcl
+++ b/chicken-coop/coopBack.kcl
@@ -1,0 +1,29 @@
+import variables from "vars.kcl"
+import pitchedStud, flatten, verticalStudGeo, studWithoutAngles from "studUtils.kcl"
+
+v = variables()
+
+fn vertStudsBack(index) {
+  position = index * v.interStudDistance
+  return [
+    verticalStudGeo(v.backPlane, [0, 0, v.studWidth], position, v.studWidth, v.studDepth, false, 'vertStudsBackWall', v.coopRoofPitch, v.coopStartHeight),
+    verticalStudGeo(v.backPlane, [0, v.coopWidth, v.studWidth], position, v.studWidth, v.studDepth, true, 'vertStudsBackWall', v.coopRoofPitch, v.coopStartHeight)
+  ]
+}
+
+export fn coopBack(plane) {
+  outsideStuds = [
+    pitchedStud(plane, false),
+    pitchedStud(plane, true),
+    verticalStudGeo(plane, [0, 0, v.studWidth], v.studWidth, v.studDepth, v.studWidth, false, 'backWallCornerStudL', v.coopRoofPitch, v.coopStartHeight),
+    verticalStudGeo(plane, [0, v.coopWidth, v.studWidth], v.studWidth, v.studDepth, v.studWidth, true, 'backWallCornerStudL', v.coopRoofPitch, v.coopStartHeight),
+    studWithoutAngles(plane, [0, 0, 0], [v.coopWidth, v.studWidth, -v.studDepth], 'backBaseOrFoot')
+  ]
+  vertStuds = flatten(  map([0 .. v.studCountBack], vertStudsBack))
+
+  return flatten([outsideStuds, vertStuds])
+}
+
+// example, uncomment to check, but should be left comment
+// otherwise causes problem importing elsewhere
+aGroupOfStudForCreatingCutList = coopBack(v.backPlane)

--- a/chicken-coop/coopFront.kcl
+++ b/chicken-coop/coopFront.kcl
@@ -1,0 +1,98 @@
+import variables from "vars.kcl"
+import pitchedStud, flatten, verticalStudGeo, studWithoutAngles from "studUtils.kcl"
+
+v = variables()
+
+fn vertStudsBetweenSideAndDoorFn(index) {
+  position = index * v.interStudDistance
+  return [
+    verticalStudGeo(v.frontPlane, [0, 0, v.studWidth], position, v.studWidth, v.studDepth, false, 'vertStudsBetweenSideAndDoorFront', v.coopRoofPitch, v.coopStartHeight),
+    verticalStudGeo(v.frontPlane, [0, v.coopWidth, v.studWidth], position, v.studWidth, v.studDepth, true, 'vertStudsBetweenSideAndDoorFront', v.coopRoofPitch, v.coopStartHeight)
+  ]
+}
+
+fn vertStudsOverDoorFn(index) {
+  position = index * v.interStudDistance + v.coopFrontFootWidth + 100
+  finalPosition = min(position, v.coopWidthHalf - v.studWidth)
+  return [
+    verticalStudGeo(v.frontPlane, [0, 0, v.coopDoorHeight + v.studDepth], finalPosition, v.studWidth, v.studDepth, false, 'vertStudsOverDoorFront', v.coopRoofPitch, v.coopStartHeight),
+    verticalStudGeo(v.frontPlane, [
+  0,
+  v.coopWidth,
+  v.coopDoorHeight + v.studDepth
+], finalPosition, v.studWidth, v.studDepth, true, "vertStudsOverMainDoor", v.coopRoofPitch, v.coopStartHeight)
+  ]
+}
+
+export fn coopFront(plane) {
+  outsideStuds = [
+    pitchedStud(plane, false),
+    pitchedStud(plane, true),
+    verticalStudGeo(plane, [0, 0, v.studWidth], v.studWidth, v.studDepth, v.studWidth, false, 'frontCornerStudL', v.coopRoofPitch, v.coopStartHeight),
+    verticalStudGeo(plane, [0, v.coopWidth, v.studWidth], v.studWidth, v.studDepth, v.studWidth, true, 'frontCornerStudL', v.coopRoofPitch, v.coopStartHeight),
+    verticalStudGeo(plane, [0, 0, v.studWidth], v.coopFrontFootWidth - (v.studWidth * 2), v.studWidth, v.studDepth, false, 'lFrontDoorVertStud', v.coopRoofPitch, v.coopStartHeight),
+    verticalStudGeo(plane, [0, v.coopWidth, v.studWidth], v.coopFrontFootWidth - (v.studWidth * 2), v.studWidth, v.studDepth, true, 'rFrontDoorVertStud', v.coopRoofPitch, v.coopStartHeight),
+    studWithoutAngles(plane, [0, 0, 0], [
+  v.coopFrontFootWidth,
+  v.studWidth,
+  -v.studDepth
+], 'frontFootL'),
+    studWithoutAngles(plane, [
+  0,
+  v.coopWidth - v.coopFrontFootWidth,
+  0
+], [
+  v.coopFrontFootWidth,
+  v.studWidth,
+  -v.studDepth
+], 'frontFootR'),
+    studWithoutAngles(plane, [
+  0,
+  v.coopFrontFootWidth - v.studWidth,
+  v.studWidth
+], [
+  v.studWidth,
+  v.coopDoorHeight - v.studWidth,
+  -v.studDepth
+], 'frontDoorSupportUnderHeaderL'),
+    studWithoutAngles(plane, [
+  0,
+  v.coopWidth - v.coopFrontFootWidth,
+  v.studWidth
+], [
+  v.studWidth,
+  v.coopDoorHeight - v.studWidth,
+  -v.studDepth
+], 'frontDoorSupportUnderHeaderR'),
+    studWithoutAngles(plane, [
+  0,
+  v.coopFrontFootWidth - v.studWidth,
+  v.coopDoorHeight + 0
+], [
+  v.coopDoorWidth + 2 * v.studWidth,
+  v.studDepth,
+  -v.studWidth
+], 'frontDoorHeader1'),
+    studWithoutAngles(plane, [
+  -v.studDepth + v.studWidth,
+  v.coopFrontFootWidth - v.studWidth,
+  v.coopDoorHeight
+], [
+  v.coopDoorWidth + 2 * v.studWidth,
+  v.studDepth,
+  -v.studWidth
+], 'frontDoorHeader2')
+  ]
+  vertStudsBetweenSideAndDoor = flatten(  map([0 .. v.studCountBetweenSideAndDoor], vertStudsBetweenSideAndDoorFn))
+
+  vertStudsOverDoor = flatten(  map([0 .. v.studCountOverDoor], vertStudsOverDoorFn))
+  return flatten([
+    outsideStuds,
+    vertStudsBetweenSideAndDoor,
+    vertStudsOverDoor
+  ])
+}
+
+// example, uncomment to check, but should be left comment
+// otherwise causes problem importing elsewhere
+// aGroupOfStudForCreatingCutList = coopFront(v.frontPlane)

--- a/chicken-coop/coopOutsideWall.kcl
+++ b/chicken-coop/coopOutsideWall.kcl
@@ -1,0 +1,208 @@
+import variables from "vars.kcl"
+import pitchedStud, flatten, verticalStudGeo, studWithoutAngles from "studUtils.kcl"
+
+v = variables()
+
+export fn coopOutsideWall(plane) {
+  fixedStuds = [
+    studWithoutAngles(plane, [0, 0, 0], [
+  v.coopFrameLength,
+  v.studWidth,
+  -v.studDepth
+], 'outsideWallFrameBase'),
+    studWithoutAngles(plane, [
+  v.coopFrameLength - (v.studWidth * 3),
+  0,
+  v.studWidth
+], [
+  v.studWidth,
+  v.nestingBoxHeight - v.studWidth,
+  -v.studDepth
+], 'outsideWallNestingHeaderSupportStudR'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength + v.studWidth * 2,
+  0,
+  v.studWidth
+], [
+  v.studWidth,
+  v.nestingBoxHeight - v.studWidth,
+  -v.studDepth
+], 'outsideWallNestingHeaderSupportStudl'),
+    studWithoutAngles(plane, [
+  v.coopFrameLength - (v.studWidth * 2),
+  0,
+  v.studWidth
+], [
+  v.studWidth,
+  v.nestingBoxHeight - v.studWidth + v.studDepth,
+  -v.studDepth
+], 'outsideWallNestingHeaderUpperSupportStudR1'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength + v.studWidth,
+  0,
+  v.studWidth
+], [
+  v.studWidth,
+  v.nestingBoxHeight - v.studWidth + v.studDepth,
+  -v.studDepth
+], 'outsideWallNestingHeaderUpperSupportStudL1'),
+    studWithoutAngles(plane, [
+  v.coopFrameLength - v.studWidth,
+  0,
+  v.studWidth
+], [
+  v.studWidth,
+  v.nestingBoxHeight - v.studWidth + v.studDepth,
+  -v.studDepth
+], 'outsideWallNestingHeaderUpperSupportStudR2'),
+    studWithoutAngles(plane, [v.coopStorageLength, 0, v.studWidth], [
+  v.studWidth,
+  v.nestingBoxHeight + v.studDepth + v.windowHeight,
+  -v.studDepth
+], 'outsideWallStorageCoopTransitionVerticalStud'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength + v.studWidth * 2,
+  0,
+  v.nestingBoxHeight
+], [
+  v.coopFrameLength - v.coopStorageLength - (4 * v.studWidth),
+  v.studDepth,
+  -v.studWidth
+], 'outsideWallNestingheader1'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength + v.studWidth * 2,
+  -v.studDepth + v.studWidth,
+  v.nestingBoxHeight
+], [
+  v.coopFrameLength - v.coopStorageLength - (4 * v.studWidth),
+  v.studDepth,
+  -v.studWidth
+], 'outsideWallNestingheader2'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength + v.studWidth,
+  0,
+  v.nestingBoxHeight + v.studDepth
+], [
+  v.coopFrameLength - v.coopStorageLength - v.studWidth,
+  v.studWidth,
+  -v.studDepth
+], 'outsideWallWindowSectionBase'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength,
+  0,
+  v.nestingBoxHeight + v.studDepth + v.windowHeight + v.studWidth
+], [
+  v.coopFrameLength - v.coopStorageLength,
+  v.studWidth,
+  -v.studDepth
+], 'outsideWallWindowHeader1'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength,
+  0,
+  v.nestingBoxHeight + v.studDepth + v.windowHeight + v.studWidth * 2
+], [
+  v.coopFrameLength - v.coopStorageLength,
+  v.studWidth,
+  -v.studDepth
+], 'outsideWallwindowHeader2'),
+    studWithoutAngles(plane, [0, 0, v.coopFrameHeight - v.studWidth], [
+  v.coopFrameLength,
+  v.studWidth,
+  -v.studDepth
+], 'outsideWallFrameTop1'),
+    studWithoutAngles(plane, [
+  0,
+  0,
+  v.coopFrameHeight - (v.studWidth * 2)
+], [
+  v.coopFrameLength,
+  v.studWidth,
+  -v.studDepth
+], 'outsideWallFrameTop1'),
+    studWithoutAngles(plane, [0, 0, v.studWidth], [
+  v.studWidth,
+  v.coopFrameHeight - (v.studWidth * 3),
+  -v.studDepth
+], 'outsideWallFrameEdgeL'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength - v.studWidth,
+  0,
+  v.studWidth
+], [
+  v.studWidth,
+  v.coopFrameHeight - (v.studWidth * 3),
+  -v.studDepth
+], 'outsideWallstorageDoorVertStudR'),
+    studWithoutAngles(plane, [
+  v.coopFrameLength - v.studWidth,
+  0,
+  v.nestingBoxHeight + v.studDepth + v.studWidth
+], [
+  v.studWidth,
+  v.windowHeight,
+  -v.studDepth
+], 'outsideWallWindowEdgeVertStud'),
+    studWithoutAngles(plane, [
+  v.coopFrameLength - v.studWidth,
+  0,
+  v.nestingBoxHeight + v.studDepth + v.studWidth + v.windowHeight + v.studWidth * 2
+], [
+  v.studWidth,
+  v.coopFrameHeight - (v.nestingBoxHeight + v.studDepth + v.studWidth + v.windowHeight + v.studWidth * 4),
+  -v.studDepth
+], 'outsideWallTopRightEdgeSupport')
+  ]
+
+  vertStudDistance = v.coopLength - v.coopStorageLength - (v.studWidth * 3)
+  vertStudCount = ceil(vertStudDistance / v.interStudDistance)
+  vertStudRemainder = vertStudDistance - ((vertStudCount - 1) * v.interStudDistance)
+  assert(vertStudDistance > v.windowCount * (v.windowWidth + v.studWidth * 2), 'windows will not fit, you either need a longer coop, less windows, or more narrow windows')
+  fn vertStudPlacer(index) {
+    position = v.interStudDistance * index - (vertStudRemainder / 2)
+    return studWithoutAngles(plane, [
+      v.coopStorageLength + position,
+      0,
+      v.nestingBoxHeight + v.studDepth + v.studWidth + v.windowHeight + v.studWidth * 2
+    ], [
+      v.studWidth,
+      v.coopFrameHeight - (v.nestingBoxHeight + v.studDepth + v.studWidth + v.windowHeight + v.studWidth * 4),
+      -v.studDepth
+    ], 'outsideWallTopVerticalStuds')
+  }
+  topVertStuds = map([1 .. vertStudCount - 1], vertStudPlacer)
+  vertStudDistanceForWindows = v.coopLength - v.coopStorageLength - (v.studWidth * 4)
+  windownPositionInterval = vertStudDistanceForWindows / (v.windowCount + 1)
+  fn windowStudPlacer(index) {
+    position = windownPositionInterval * index
+    return [
+      studWithoutAngles(plane, [
+  v.coopStorageLength + position - v.studWidth - (v.windowWidth / 2),
+  0,
+  v.nestingBoxHeight + v.studDepth + v.studWidth
+], [
+  v.studWidth,
+  v.windowHeight,
+  -v.studDepth
+], 'outsideWallWindowEdgeStud'),
+      studWithoutAngles(plane, [
+  v.coopStorageLength + position - v.studWidth + v.windowWidth / 2,
+  0,
+  v.nestingBoxHeight + v.studDepth + v.studWidth
+], [
+  v.studWidth,
+  v.windowHeight,
+  -v.studDepth
+], 'outsideWallWindowEdgeStud')
+    ]
+  }
+  windowEdgeStuds = flatten(  map([1 .. v.windowCount], windowStudPlacer))
+  return flatten([
+    fixedStuds,
+    windowEdgeStuds,
+    topVertStuds
+  ])
+}
+
+// example, uncomment to check, but should be left comment
+// otherwise causes problem importing elsewhere
+// aGroupOfStudForCreatingCutList = coopOutsideWall(v.outsideWallPlane)

--- a/chicken-coop/coopRoof.kcl
+++ b/chicken-coop/coopRoof.kcl
@@ -1,0 +1,240 @@
+import variables from "vars.kcl"
+import pitchedStud, pitchedStud2, flatten, verticalStudGeo, studWithoutAngles, concat from "studUtils.kcl"
+
+v = variables()
+
+runRafterCount = v.runRafterCount
+interRafterDistance = v.interRafterDistance
+runEndPlane = v.runEndPlane
+coopLength = v.coopLength
+runDoorWidth = v.runDoorWidth
+studWidth = v.studWidth
+studDepth = v.studDepth
+runRoofPitchR = v.runRoofPitchR
+runRoofPitch = v.runRoofPitch
+heightOfRunEndWall = v.heightOfRunEndWall
+studThicknessAtRunAngle = v.studThicknessAtRunAngle
+runPitchedStudLen = v.runPitchedStudLen
+runDoorHeight = v.runDoorHeight
+runHorzBraceHeight = v.runHorzBraceHeight
+studTallSideThicknessAtRunAngle = v.studTallSideThicknessAtRunAngle
+runSideEaveOverHang = v.runSideEaveOverHang
+rafterCommonZ = v.rafterCommonZ
+runRafterCommonHorizontalDistance = v.runRafterCommonHorizontalDistance
+ridgeWidth = v.ridgeWidth
+runRafterRatio = v.runRafterRatio
+frontRoofAngle = v.frontRoofAngle
+xCoordForRunHorzSupportFront = v.xCoordForRunHorzSupportFront
+xCoordForRunHorzSupportBack = v.xCoordForRunHorzSupportBack
+heightToNotchIntoRafters = v.heightToNotchIntoRafters
+nestingBoxDepth = v.nestingBoxDepth
+nestingRoofPitch = v.nestingRoofPitch
+nestingRoofPitchR = v.nestingRoofPitchR
+frontPlane = v.frontPlane
+coopStorageLength = v.coopStorageLength
+nestingBoxHeight = v.nestingBoxHeight
+backEaveOverHang = v.backEaveOverHang
+coopWidthHalf = v.coopWidthHalf
+coopStartHeight = v.coopStartHeight
+coopRoofPitchR = v.coopRoofPitchR
+ridgeDepth = v.ridgeDepth
+studThicknessAtAngle = v.studThicknessAtAngle
+studTallSideThicknessAtAngle = v.studTallSideThicknessAtAngle
+frontEaveOverHang = v.frontEaveOverHang
+sideEaveOverHang = v.sideEaveOverHang
+bottOfSideEaveHeight = v.bottOfSideEaveHeight
+coopWidth = v.coopWidth
+leftRafterY = v.leftRafterY
+rafterLength = v.rafterLength
+rightRafterY = v.rightRafterY
+leftRafterAngle = v.leftRafterAngle
+rightRafterAngle = v.rightRafterAngle
+rafterCommonHorzLength = v.rafterCommonHorzLength
+rafterRatioForAngle = v.rafterRatioForAngle
+interStudDistance = v.interStudDistance
+coopRoofPitch = v.coopRoofPitch
+backPlane = v.backPlane
+angleFromCoopRoofToRunRoof = v.angleFromCoopRoofToRunRoof
+horizontalLengthAlongRunFromvalleyToTip = v.horizontalLengthAlongRunFromvalleyToTip
+
+fudgeOffsetForFlashing = 70
+xComponetCompensationForFudge = fudgeOffsetForFlashing / tan(coopRoofPitchR)
+
+angang = coopRoofPitch + 270
+coopRoofPlane1 = {
+  plane = {
+    origin = [
+      -runSideEaveOverHang,
+      coopWidth + sideEaveOverHang - xComponetCompensationForFudge,
+      rafterCommonZ + studTallSideThicknessAtAngle + fudgeOffsetForFlashing
+    ],
+    xAxis = [1, 0, 0],
+    yAxis = [
+      0,
+      sin(toRadians(angang)),
+      cos(toRadians(angang))
+    ],
+    zAxis = [
+      0,
+      cos(toRadians(angang)),
+      sin(toRadians(angang))
+    ]
+  }
+}
+
+fn runValleyFlashingBattenForCoop(plane, flip) {
+  multiplier = if flip {
+    1
+  } else {
+    -1
+  }
+  angleFromCoopRoofToRunRoof2 = if flip {
+    -angleFromCoopRoofToRunRoof
+  } else {
+    angleFromCoopRoofToRunRoof
+  }
+  xStart = if flip {
+    coopLength + runSideEaveOverHang - studDepth
+  } else {
+    0
+  }
+
+  runRafterLength = (coopLength / 2 + runSideEaveOverHang - studWidth) / cos(runRoofPitchR)
+  valleyLength = sqrt(pow(horizontalLengthAlongRunFromvalleyToTip, 2) + pow(runRafterLength, 2))
+
+  sketch001 = startSketchOn(plane)
+    |> startProfileAt([xStart, 0], %)
+    |> angledLine([
+         -270 - angleFromCoopRoofToRunRoof2,
+         valleyLength
+       ], %, $seg01)
+    |> angledLineOfXLength({ angle = 0, length = studDepth }, %)
+    |> angledLine([segAng(seg01) + 180, segLen(seg01)], %)
+    |> lineTo([profileStartX(%), profileStartY(%)], %)
+    |> close(%)
+    |> extrude(-studWidth, %)
+  lengthOfAngleForCut = tan(toDegrees(angleFromCoopRoofToRunRoof2)) * studDepth
+  widthOfFlashing = 150
+  lengthOfAngleForFlashing = tan(toDegrees(angleFromCoopRoofToRunRoof2)) * widthOfFlashing
+  return 
+    {
+  // stud = extrude002,
+  // safeCutLength = safeCutLength,
+  lengthBeforeAngles = valleyLength - lengthOfAngleForCut,
+  name = "valleyRunStud",
+  studType = [v.studWidth, "by", v.studDepth],
+  angleRelevantWidth = v.studWidth,
+  endCut1 = v.angleFromCoopRoofToRunRoof,
+  endCut2 = v.angleFromCoopRoofToRunRoof
+}
+  
+}
+
+fn rafterFn(index) {
+  position = interStudDistance * index
+  positionForRafterOnFrame = coopLength / 2 - (studWidth / 2) - interStudDistance
+  finalPosition = if position > positionForRafterOnFrame {
+    positionForRafterOnFrame
+  } else {
+    position
+  }
+  frontPosition = -studDepth + studWidth / 2 + coopLength / 2 + interStudDistance + finalPosition
+  backPosition = -studDepth + studWidth / 2 - finalPosition + coopLength / 2 - interStudDistance
+  return [
+    pitchedStud2("raftersLeftFront", backPlane, [
+  frontPosition,
+  leftRafterY,
+  rafterCommonZ
+], studDepth, studWidth, (coopWidthHalf + sideEaveOverHang - (ridgeWidth / 2)) / cos(toRadians(coopRoofPitch)), leftRafterAngle),
+    pitchedStud2("raftersLeftBack", backPlane, [
+  backPosition,
+  leftRafterY,
+  rafterCommonZ
+], studDepth, studWidth, (coopWidthHalf + sideEaveOverHang - (ridgeWidth / 2)) / cos(toRadians(coopRoofPitch)), leftRafterAngle),
+    pitchedStud2("raftersRightFront", backPlane, [
+  frontPosition,
+  rightRafterY,
+  rafterCommonZ + studTallSideThicknessAtAngle
+], studDepth, studWidth, (coopWidthHalf + sideEaveOverHang - (ridgeWidth / 2)) / cos(toRadians(coopRoofPitch)), rightRafterAngle),
+    pitchedStud2("raftersRightBack", backPlane, [
+  backPosition,
+  rightRafterY,
+  rafterCommonZ + studTallSideThicknessAtAngle
+], studDepth, studWidth, (coopWidthHalf + sideEaveOverHang - (ridgeWidth / 2)) / cos(toRadians(coopRoofPitch)), rightRafterAngle)
+  ]
+}
+
+export fn coopRoof(plane) {
+  outsideStuds = [
+//     studWithoutAngles(plane, [
+//   -backEaveOverHang,
+//   coopWidthHalf - (ridgeWidth / 2),
+//   coopStartHeight + tan(coopRoofPitchR) * coopWidthHalf - ridgeDepth + studThicknessAtAngle - (tan(coopRoofPitchR) * ridgeWidth / 2) + studTallSideThicknessAtAngle
+// ], [
+//   ridgeWidth,
+//   ridgeDepth,
+//   coopLength + backEaveOverHang + frontEaveOverHang - (studWidth * 2)
+// ], 'coopRidge'),
+//     studWithoutAngles(plane, [
+//   -backEaveOverHang - studWidth,
+//   -sideEaveOverHang - studWidth,
+//   bottOfSideEaveHeight
+// ], [
+//   studWidth,
+//   studDepth,
+//   coopLength + backEaveOverHang + frontEaveOverHang
+// ], 'coopGutterLineNestBoxSide'),
+    studWithoutAngles(plane, [
+  -backEaveOverHang - studWidth,
+  sideEaveOverHang + coopWidth,
+  bottOfSideEaveHeight
+], [
+  studWidth,
+  studDepth,
+  coopLength + backEaveOverHang + frontEaveOverHang
+], 'coopGutterLineRunSide'),
+    pitchedStud2("coopCenterRafterL", plane, [
+  -studDepth + studWidth + coopLength / 2 - (studWidth / 2),
+  leftRafterY,
+  rafterCommonZ
+], studDepth, studWidth, rafterLength, leftRafterAngle),
+    pitchedStud2("coopCenterRafterR", plane, [
+  -studDepth + studWidth + coopLength / 2 - (studWidth / 2),
+  rightRafterY,
+  rafterCommonZ + studTallSideThicknessAtAngle
+], studDepth, studWidth, rafterLength, rightRafterAngle),
+    pitchedStud2("coopBackEndRafterL", plane, [
+  -backEaveOverHang,
+  leftRafterY,
+  rafterCommonZ
+], studDepth, studWidth, (rafterCommonHorzLength + ridgeWidth / 2) / rafterRatioForAngle, leftRafterAngle),
+    pitchedStud2("coopBackEndRafterR", plane, [
+  -backEaveOverHang,
+  rightRafterY,
+  rafterCommonZ + studTallSideThicknessAtAngle
+], studDepth, studWidth, (rafterCommonHorzLength + ridgeWidth / 2) / rafterRatioForAngle, rightRafterAngle),
+    pitchedStud2("coopFrontEndRafterL", plane, [
+  coopLength + frontEaveOverHang - studWidth,
+  leftRafterY,
+  rafterCommonZ
+], studDepth, studWidth, (rafterCommonHorzLength + ridgeWidth / 2) / rafterRatioForAngle, leftRafterAngle),
+    pitchedStud2("coopFrontEndRafterR", plane, [
+  coopLength + frontEaveOverHang - studWidth,
+  rightRafterY,
+  rafterCommonZ + studTallSideThicknessAtAngle
+], studDepth, studWidth, (rafterCommonHorzLength + ridgeWidth / 2) / rafterRatioForAngle, rightRafterAngle)
+  ]
+  rafterCount = ceil((coopLength / 2 - interStudDistance - (studWidth * 2)) / interStudDistance)
+  rafters = flatten(  map([0..rafterCount], rafterFn))
+  return flatten([
+    rafters,
+    outsideStuds,
+    [runValleyFlashingBattenForCoop(coopRoofPlane1, false),
+    runValleyFlashingBattenForCoop(coopRoofPlane1, true)],
+  ])
+}
+
+// example, uncomment to check, but should be left comment
+// otherwise causes problem importing elsewhere
+// aGroupOfStudForCreatingCutList = coopRoof(v.backPlane)
+

--- a/chicken-coop/coopRunWall.kcl
+++ b/chicken-coop/coopRunWall.kcl
@@ -1,0 +1,208 @@
+import variables from "vars.kcl"
+import pitchedStud, flatten, verticalStudGeo, studWithoutAngles, concat from "studUtils.kcl"
+
+v = variables()
+
+export fn coopRunWall(plane) {
+  fixedStuds = [
+    studWithoutAngles(plane, [0, 0, 0], [
+  v.coopFrameLength,
+  v.studWidth,
+  -v.studDepth
+], 'runWallFrameBase'),
+    studWithoutAngles(plane, [
+  v.coopFrameLength - (v.studWidth * 2),
+  0,
+  v.studWidth
+], [
+  v.studWidth,
+  v.nestingBoxHeight - v.studWidth + v.studDepth,
+  -v.studDepth
+], 'runWallNestingHeaderUpperSupportStudR1'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength + v.studWidth,
+  0,
+  v.studWidth
+], [
+  v.studWidth,
+  v.nestingBoxHeight - v.studWidth + v.studDepth,
+  -v.studDepth
+], 'runWallNestingHeaderUpperSupportStudL1'),
+    studWithoutAngles(plane, [
+  v.coopFrameLength - v.studWidth,
+  0,
+  v.studWidth
+], [
+  v.studWidth,
+  v.nestingBoxHeight - v.studWidth + v.studDepth,
+  -v.studDepth
+], 'runWallNestingHeaderUpperSupportStudR2'),
+    studWithoutAngles(plane, [v.coopStorageLength, 0, v.studWidth], [
+  v.studWidth,
+  v.nestingBoxHeight + v.studDepth + v.windowHeight,
+  -v.studDepth
+], 'runWallStorageCoopTransitionVerticalStud'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength + v.studWidth,
+  0,
+  v.nestingBoxHeight + v.studDepth
+], [
+  v.coopFrameLength - v.coopStorageLength - v.studWidth,
+  v.studWidth,
+  -v.studDepth
+], 'runWallWindowSectionBase'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength,
+  0,
+  v.nestingBoxHeight + v.studDepth + v.windowHeight + v.studWidth
+], [
+  v.coopFrameLength - v.coopStorageLength,
+  v.studWidth,
+  -v.studDepth
+], 'runWallwindowHeader1'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength,
+  0,
+  v.nestingBoxHeight + v.studDepth + v.windowHeight + v.studWidth * 2
+], [
+  v.coopFrameLength - v.coopStorageLength,
+  v.studWidth,
+  -v.studDepth
+], 'runWallwindowHeader2'),
+    studWithoutAngles(plane, [0, 0, v.coopFrameHeight - v.studWidth], [
+  v.coopFrameLength,
+  v.studWidth,
+  -v.studDepth
+], 'runWallFrameTop1'),
+    studWithoutAngles(plane, [
+  0,
+  0,
+  v.coopFrameHeight - (v.studWidth * 2)
+], [
+  v.coopFrameLength,
+  v.studWidth,
+  -v.studDepth
+], 'runWallFrameTop1'),
+    studWithoutAngles(plane, [0, 0, v.studWidth], [
+  v.studWidth,
+  v.coopFrameHeight - (v.studWidth * 3),
+  -v.studDepth
+], 'runWallFrameEdgeL'),
+    studWithoutAngles(plane, [
+  v.coopStorageLength - v.studWidth,
+  0,
+  v.studWidth
+], [
+  v.studWidth,
+  v.coopFrameHeight - (v.studWidth * 3),
+  -v.studDepth
+], 'runWallstorageDoorVertStudR'),
+    studWithoutAngles(plane, [
+  v.coopFrameLength - v.studWidth,
+  0,
+  v.nestingBoxHeight + v.studDepth + v.studWidth
+], [
+  v.studWidth,
+  v.windowHeight,
+  -v.studDepth
+], 'runWallwindowEdgeVertStud'),
+    studWithoutAngles(plane, [
+  v.coopFrameLength - v.studWidth,
+  0,
+  v.nestingBoxHeight + v.studDepth + v.studWidth + v.windowHeight + v.studWidth * 2
+], [
+  v.studWidth,
+  v.coopFrameHeight - (v.nestingBoxHeight + v.studDepth + v.studWidth + v.windowHeight + v.studWidth * 4),
+  -v.studDepth
+], 'runWalltopRightEdgeSupport')
+  ]
+
+  vertStudDistance = v.coopLength - v.coopStorageLength - (v.studWidth * 3)
+  vertStudCount = ceil(vertStudDistance / v.interStudDistance)
+  vertStudRemainder = vertStudDistance - ((vertStudCount - 1) * v.interStudDistance)
+  assert(vertStudDistance > v.windowCount * (v.windowWidth + v.studWidth * 2), 'windows will not fit, you either need a longer coop, less windows, or more narrow windows')
+  fn vertStudPlacer(index) {
+    position = v.interStudDistance * index - (vertStudRemainder / 2)
+    result = [
+      studWithoutAngles(plane, [
+  v.coopStorageLength + position,
+  0,
+  v.nestingBoxHeight + v.studDepth + v.studWidth + v.windowHeight + v.studWidth * 2
+], [
+  v.studWidth,
+  v.coopFrameHeight - (v.nestingBoxHeight + v.studDepth + v.studWidth + v.windowHeight + v.studWidth * 4),
+  -v.studDepth
+], 'runWalltopVerticalStud'),
+      studWithoutAngles(plane, [
+  v.coopStorageLength + position,
+  0,
+  v.studWidth
+], [
+  v.studWidth,
+  v.nestingBoxHeight - v.studWidth + v.studDepth,
+  -v.studDepth
+], 'runWallbottomVerticalStud')
+    ]
+//     pushedResult = if index == 1 {
+//       concat(result, [
+//         studWithoutAngles(plane, [
+//   v.coopStorageLength + position + v.studWidth,
+//   0,
+//   v.studWidth + v.chickenDoorHeight
+// ], [
+//   v.interStudDistance - v.studWidth,
+//   v.studDepth,
+//   -v.studWidth
+// ], 'runWallchickenDoorHeader1'),
+//         studWithoutAngles(plane, [
+//   v.coopStorageLength + position + v.studWidth,
+//   -v.studDepth + v.studWidth,
+//   v.studWidth + v.chickenDoorHeight
+// ], [
+//   v.interStudDistance - v.studWidth,
+//   v.studDepth,
+//   -v.studWidth
+// ], 'runWallchickenDoorHeader2')
+//       ])
+//     } else {
+//       result
+//     }
+    return result
+  }
+  topVertStuds = flatten(  map([1 .. vertStudCount - 1], vertStudPlacer))
+  vertStudDistanceForWindows = v.coopLength - v.coopStorageLength - (v.studWidth * 4)
+  windownPositionInterval = vertStudDistanceForWindows / (v.windowCount + 1)
+  fn windowStudPlacer(index) {
+    position = windownPositionInterval * index
+    return [
+      studWithoutAngles(plane, [
+  v.coopStorageLength + position - v.studWidth - (v.windowWidth / 2),
+  0,
+  v.nestingBoxHeight + v.studDepth + v.studWidth
+], [
+  v.studWidth,
+  v.windowHeight,
+  -v.studDepth
+], 'runWallwindownEdgeStudsL'),
+      studWithoutAngles(plane, [
+  v.coopStorageLength + position - v.studWidth + v.windowWidth / 2,
+  0,
+  v.nestingBoxHeight + v.studDepth + v.studWidth
+], [
+  v.studWidth,
+  v.windowHeight,
+  -v.studDepth
+], 'runWallwindownEdgeStudsR')
+    ]
+  }
+  windowEdgeStuds = flatten(  map([1 .. v.windowCount], windowStudPlacer))
+  return flatten([
+    fixedStuds,
+    windowEdgeStuds,
+    topVertStuds
+  ])
+}
+
+// example, uncomment to check, but should be left comment
+// otherwise causes problem importing elsewhere
+aGroupOfStudForCreatingCutList = coopRunWall(v.runWallPlane)

--- a/chicken-coop/foundation.kcl
+++ b/chicken-coop/foundation.kcl
@@ -1,0 +1,137 @@
+import variables from "vars.kcl"
+import pitchedStud, flatten, verticalStudGeo, studWithoutAngles from "studUtils.kcl"
+
+v = variables()
+coopWidth = v.coopWidth
+studWidth = v.studWidth
+coopLength = v.coopLength
+interStudDistance = v.interStudDistance
+
+export fn foundation() {
+  fixedStuds = [
+    studWithoutAngles(v.backPlane, [-v.studDepth, 0, -v.studDepth], [v.studWidth, v.studDepth, v.coopLength], 'foundationNestingBoxSideOutside'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth,
+  v.totalLength - v.studWidth,
+  -v.studDepth
+], [v.studWidth, v.studDepth, v.coopLength], 'foundationRunEndSideOutside'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth + v.studWidth,
+  v.studWidth,
+  -v.studDepth
+], [
+  v.studWidth,
+  v.studDepth,
+  v.coopLength - (v.studWidth * 2)
+], 'foundationNestingBoxSideInside'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth + v.studWidth,
+  v.totalLength - (v.studWidth * 2),
+  -v.studDepth
+], [
+  v.studWidth,
+  v.studDepth,
+  v.coopLength - (v.studWidth * 2)
+], 'foundationRunEndSideInside'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth + v.studWidth,
+  v.studWidth,
+  -v.studDepth
+], [
+  v.totalLength / 2 - v.studWidth - v.foundationStudOverlap,
+  v.studDepth,
+  -v.studWidth
+], 'foundationBackOutside1'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth + v.studWidth,
+  v.totalLength / 2 - v.foundationStudOverlap,
+  -v.studDepth
+], [
+  v.totalLength / 2 - v.studWidth + v.foundationStudOverlap,
+  v.studDepth,
+  -v.studWidth
+], 'foundationBackOutside2'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth + v.studWidth * 2,
+  v.studWidth * 2,
+  -v.studDepth
+], [
+  v.totalLength / 2 - (v.studWidth * 2) + v.foundationStudOverlap,
+  v.studDepth,
+  -v.studWidth
+], 'foundationBackInside1'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth + v.studWidth * 2,
+  v.totalLength / 2 + v.foundationStudOverlap,
+  -v.studDepth
+], [
+  v.totalLength / 2 - (v.studWidth * 2) - v.foundationStudOverlap,
+  v.studDepth,
+  -v.studWidth
+], 'foundationBackInside2'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth + v.coopLength,
+  v.studWidth,
+  -v.studDepth
+], [
+  v.totalLength / 2 - v.studWidth - v.foundationStudOverlap,
+  v.studDepth,
+  -v.studWidth
+], 'foundationFrontOutside1'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth + v.coopLength,
+  v.studWidth + v.totalLength / 2 - v.studWidth - v.foundationStudOverlap,
+  -v.studDepth
+], [
+  v.totalLength / 2 - v.studWidth + v.foundationStudOverlap,
+  v.studDepth,
+  -v.studWidth
+], 'foundationFrontOutside2'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth - v.studWidth + v.coopLength,
+  v.studWidth * 2,
+  -v.studDepth
+], [
+  v.totalLength / 2 - (v.studWidth * 2) + v.foundationStudOverlap,
+  v.studDepth,
+  -v.studWidth
+], 'foundationFrontInside1'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth + v.coopLength - v.studWidth,
+  v.totalLength / 2 + v.foundationStudOverlap,
+  -v.studDepth
+], [
+  v.totalLength / 2 - (v.studWidth * 2) - v.foundationStudOverlap,
+  v.studDepth,
+  -v.studWidth
+], 'foundationFrontInside2'),
+    studWithoutAngles(v.backPlane, [
+  -v.studDepth + studWidth * 2,
+  coopWidth - studWidth,
+  -v.studDepth
+], [
+  v.studWidth,
+  v.studDepth,
+  v.coopLength - (studWidth * 4)
+], 'foundationRunSideFloorSupport')
+  ]
+  studCount = floor(coopLength / interStudDistance)
+  fn floorStudPlacer(index) {
+    position = index * interStudDistance
+    return studWithoutAngles(v.backPlane, [
+      -v.studDepth + v.studWidth + position,
+      v.studWidth * 2,
+      -v.studDepth
+    ], [
+      coopWidth - (studWidth * 3),
+      v.studDepth,
+      -v.studWidth
+    ], 'foundationCoopJoist')
+  }
+  floorStuds = map([0..studCount], floorStudPlacer)
+  return flatten([fixedStuds, floorStuds])
+}
+
+// example, uncomment to check, but should be left comment
+// otherwise causes problem importing elsewhere
+// aGroupOfStudForCreatingCutList = foundation()

--- a/chicken-coop/main.kcl
+++ b/chicken-coop/main.kcl
@@ -1,0 +1,135 @@
+fn planeAboutZ(ang, origin) {
+  return {
+    plane = {
+      origin = origin,
+      yAxis = [
+        sin(toRadians(ang)),
+        cos(toRadians(ang)),
+        0.0
+      ],
+      xAxis = [0.0, 0.0, 1.0],
+      zAxis = [1.0, 0.0, 0.0]
+    }
+  }
+}
+// plane on the xz that rotates about the zAxis
+fn xy(origin, ang) {
+  angRads = toRadians(ang)
+  cosAng = cos(angRads)
+  sinAng = sin(angRads)
+  return {
+    plane = {
+      origin = [0, 0, 0],
+      xAxis = [cosAng, sinAng, 0],
+      yAxis = [-sinAng, cosAng, 0],
+      zAxis = [0, 0, 1]
+    }
+  }
+}
+
+// plane on the xz that rotates about the yAxis
+fn xz(origin, ang) {
+  angRads = toRadians(ang)
+  cosAng = cos(angRads)
+  sinAng = sin(angRads)
+  return {
+    plane = {
+      origin = origin,
+      xAxis = [cosAng, 0, -sinAng],
+      yAxis = [sinAng, 0, cosAng],
+      zAxis = [0, 1, 0]
+    }
+  }
+}
+
+// plane on the YZ that rotates about the xAxis
+fn yz(origin, ang) {
+  angRads = toRadians(ang)
+  cosAng = cos(angRads)
+  sinAng = sin(angRads)
+  return {
+    plane = {
+      origin = origin,
+      zAxis = [1, 0, 0],
+      xAxis = [0, cosAng, sinAng],
+      yAxis = [0, -sinAng, cosAng]
+    }
+  }
+}
+
+fn member(origin, ang1, ang2, length, width, depth, studAng) {
+  memberAng1 = 90 - ang1
+  memberAng2 = ang2
+  memberHeight = depth
+  memberHalfHeight = memberHeight / 2
+  memberLength = length
+  myAng = 45
+  sketch001 = startSketchOn(xz(origin, studAng))
+    |> startProfileAt([0, 0], %)
+    |> angledLineToY([memberAng1, memberHalfHeight], %, $seg02)
+    |> xLine(memberLength, %)
+    |> angledLineToY([-memberAng2, ZERO], %, $seg01)
+    |> angledLine([segAng(seg01), segLen(seg01)], %)
+    |> angledLineThatIntersects({
+         angle = HALF_TURN,
+         offset = -0,
+         intersectTag = seg02
+       }, %)
+    |> lineTo([profileStartX(%), profileStartY(%)], %)
+    |> close(%)
+  extrude001 = extrude(width, sketch001)
+  return extrude001
+}
+
+commomMemberWidth = 35
+commomMemberDepth = 90
+roof1Pitch = 20
+trussWidth = 6200
+trussWidthHalf = trussWidth / 2
+studWidth = 600
+spacteToFillWithStuds = trussWidthHalf - studWidth
+studsCount = ceil(spacteToFillWithStuds / studWidth)
+
+roofStartHeight = 2000
+
+fn fillerVertialStud(index) {
+  return if (index * studWidth + commomMemberDepth*2) >= trussWidthHalf {
+    member([
+  -commomMemberDepth*1.5 + trussWidthHalf,
+  0,
+  0
+], 0, 90 - roof1Pitch, roofStartHeight - (commomMemberDepth / cos(toRadians(roof1Pitch))) + tan(toRadians(roof1Pitch)) * (trussWidthHalf - commomMemberDepth*2), commomMemberWidth, commomMemberDepth, -90)
+  } else {
+    member([
+      commomMemberDepth / 2 + studWidth * index,
+      0,
+      0
+    ], 0, 90 - roof1Pitch, roofStartHeight - (commomMemberDepth / cos(toRadians(roof1Pitch))) + tan(toRadians(roof1Pitch)) * studWidth * index, commomMemberWidth, commomMemberDepth, -90)
+  }
+}
+
+// filler1 = fillerVertialStud(1)
+// filler2 = fillerVertialStud(2)
+// filler3 = fillerVertialStud(3)
+// filler4 = fillerVertialStud(4)
+circles = map([1..studsCount], fillerVertialStud)
+
+roofPitchMember = member([
+  0,
+  0,
+  -commomMemberDepth / 2 / cos(toRadians(roof1Pitch)) + roofStartHeight
+], roof1Pitch, 90 + roof1Pitch, trussWidthHalf / cos(toRadians(roof1Pitch)), commomMemberWidth, commomMemberDepth, -roof1Pitch)
+
+startVerticalMember = member([commomMemberDepth / 2, 0, 0], 0, 90 - roof1Pitch, roofStartHeight - (commomMemberDepth / cos(toRadians(roof1Pitch))), commomMemberWidth, commomMemberDepth, -90)
+
+endVerticalMember = member([
+  -commomMemberDepth / 2 + trussWidthHalf,
+  0,
+  0
+], 0, 90 - roof1Pitch, roofStartHeight - (commomMemberDepth / cos(toRadians(roof1Pitch))) + tan(toRadians(roof1Pitch)) * (trussWidthHalf - commomMemberDepth), commomMemberWidth, commomMemberDepth, -90)
+
+sketch002 = startSketchOn('XZ')
+  |> startProfileAt([trussWidthHalf, 0], %)
+  |> xLineTo(ZERO, %)
+  |> yLine(roofStartHeight, %)
+  |> angledLine([roof1Pitch, 2171.89], %)

--- a/chicken-coop/nestingBox.kcl
+++ b/chicken-coop/nestingBox.kcl
@@ -1,0 +1,82 @@
+import variables from "vars.kcl"
+import pitchedStud, pitchedStud2, flatten, verticalStudGeo, studWithoutAngles, concat from "studUtils.kcl"
+
+v = variables()
+
+runRafterCount = v.runRafterCount
+interRafterDistance = v.interRafterDistance
+runEndPlane = v.runEndPlane
+coopLength = v.coopLength
+runDoorWidth = v.runDoorWidth
+studWidth = v.studWidth
+studDepth = v.studDepth
+runRoofPitchR = v.runRoofPitchR
+runRoofPitch = v.runRoofPitch
+heightOfRunEndWall = v.heightOfRunEndWall
+studThicknessAtRunAngle = v.studThicknessAtRunAngle
+runPitchedStudLen = v.runPitchedStudLen
+runDoorHeight = v.runDoorHeight
+runHorzBraceHeight = v.runHorzBraceHeight
+studTallSideThicknessAtRunAngle = v.studTallSideThicknessAtRunAngle
+runSideEaveOverHang = v.runSideEaveOverHang
+rafterCommonZ = v.rafterCommonZ
+runRafterCommonHorizontalDistance = v.runRafterCommonHorizontalDistance
+ridgeWidth = v.ridgeWidth
+runRafterRatio = v.runRafterRatio
+frontRoofAngle = v.frontRoofAngle
+xCoordForRunHorzSupportFront = v.xCoordForRunHorzSupportFront
+xCoordForRunHorzSupportBack = v.xCoordForRunHorzSupportBack
+heightToNotchIntoRafters = v.heightToNotchIntoRafters
+nestingBoxDepth = v.nestingBoxDepth
+nestingRoofPitch = v.nestingRoofPitch
+nestingRoofPitchR = v.nestingRoofPitchR
+frontPlane = v.frontPlane
+coopStorageLength = v.coopStorageLength
+nestingBoxHeight = v.nestingBoxHeight
+
+export fn nestingBox() {
+  nestingPitchLength = nestingBoxDepth / cos(nestingRoofPitchR)
+  nestingVerticalComponent = nestingBoxDepth * tan(nestingRoofPitchR)
+
+  nestingBits = [
+    studWithoutAngles(frontPlane, [
+  -studDepth - (studWidth * 2),
+  0,
+  studDepth
+], [
+  -nestingBoxDepth + studDepth,
+  studDepth,
+  studWidth
+], 'nestingFrame1Front'),
+    studWithoutAngles(frontPlane, [
+  -coopLength + coopStorageLength + studDepth + studWidth,
+  0,
+  studDepth
+], [
+  -nestingBoxDepth + studDepth,
+  studDepth,
+  studWidth
+], 'nestingFrame1FrontBack'),
+    pitchedStud2("nestingFrame2Front", frontPlane, [
+  -studDepth - studWidth,
+  -nestingBoxDepth,
+  -nestingVerticalComponent + nestingBoxHeight
+], studDepth, studWidth, nestingPitchLength, nestingRoofPitch),
+    pitchedStud2("nestingFrame2Back", frontPlane, [
+  -coopLength + coopStorageLength + studDepth + studWidth * 2,
+  -nestingBoxDepth,
+  -nestingVerticalComponent + nestingBoxHeight
+], studDepth, studWidth, nestingPitchLength, nestingRoofPitch),
+    verticalStudGeo(frontPlane, [-studDepth - studWidth, 0, 0], -nestingBoxDepth, studDepth, studWidth, false, 'nestingFrame3Front', nestingRoofPitch, nestingBoxHeight),
+    verticalStudGeo(frontPlane, [
+  -coopLength + coopStorageLength + studDepth + studWidth * 2,
+  0,
+  0
+], -nestingBoxDepth, studDepth, studWidth, false, 'nestingFrame3Back', nestingRoofPitch, nestingBoxHeight)
+  ]
+  return nestingBits
+}
+
+// example, uncomment to check, but should be left comment
+// otherwise causes problem importing elsewhere
+// aGroupOfStudForCreatingCutList = nestingBox()

--- a/chicken-coop/project.toml
+++ b/chicken-coop/project.toml
@@ -1,0 +1,1 @@
+[settings]

--- a/chicken-coop/rafterBrace.kcl
+++ b/chicken-coop/rafterBrace.kcl
@@ -1,0 +1,45 @@
+export fn rafterBrace(plane, origin, angle, length, width, depth) {
+  xComponent = depth / tan(toRadians(angle))
+  shortSideLength = length - (xComponent * 2)
+  sketch001 = startSketchOn({
+         plane = {
+           origin = [
+             plane.plane.origin[0] + origin[0],
+             plane.plane.origin[1] + origin[1],
+             plane.plane.origin[2] + origin[2]
+           ],
+           xAxis = plane.plane.xAxis,
+           yAxis = plane.plane.yAxis,
+           zAxis = plane.plane.zAxis
+         }
+       })
+    |> startProfileAt([shortSideLength / 2 + xComponent, 0], %)
+    |> angledLineOfYLength({ length = depth, angle = 180 - angle }, %)
+    |> xLine(-shortSideLength, %)
+    |> angledLineOfYLength({ length = depth, angle = 180 + angle }, %)
+    |> lineTo([profileStartX(%), profileStartY(%)], %)
+    |> close(%)
+    |> extrude(width, %)
+  return {
+    // stud = extrude002,
+    // safeCutLength = safeCutLength,
+    lengthBeforeAngles = shortSideLength,
+    name = "rafterBrace",
+    studType = [width, "by", depth],
+    angleRelevantWidth = depth,
+    endCut1 = 90 - angle,
+    endCut2 = 90 - angle
+  }
+}
+
+// angle = 23
+// length = 800
+// depth = 90
+// rafter({
+//   plane = {
+//     origin = [0, 0, 0],
+//     xAxis = [1, 0, 0],
+//     yAxis = [0, 0, 1],
+//     zAxis = [0, 1, 0]
+//   }
+// }, [0, 0, 0], angle, length, 35, depth)

--- a/chicken-coop/runEnd.kcl
+++ b/chicken-coop/runEnd.kcl
@@ -1,0 +1,145 @@
+import variables from "vars.kcl"
+import pitchedStud, pitchedStud2, flatten, verticalStudGeo, studWithoutAngles from "studUtils.kcl"
+
+v = variables()
+coopLength = v.coopLength
+runDoorWidth = v.runDoorWidth
+studWidth = v.studWidth
+studDepth = v.studDepth
+runRoofPitchR = v.runRoofPitchR
+runEndPlane = v.runEndPlane
+runRoofPitch = v.runRoofPitch
+heightOfRunEndWall = v.heightOfRunEndWall
+studThicknessAtRunAngle = v.studThicknessAtRunAngle
+runPitchedStudLen = v.runPitchedStudLen
+runDoorHeight = v.runDoorHeight
+runHorzBraceHeight = v.runHorzBraceHeight
+studTallSideThicknessAtRunAngle = v.studTallSideThicknessAtRunAngle
+
+export fn runEnd() {
+  runEndFootLength = (coopLength - runDoorWidth) / 2
+  runPitchedBraceLen = (runEndFootLength - (studWidth * 3) - (studDepth * 2)) / cos(runRoofPitchR)
+  runEndWallBits = [
+    studWithoutAngles(runEndPlane, [-studDepth, 0, 0], [
+  runEndFootLength,
+  studWidth,
+  -studDepth
+], 'runEndFootL'),
+    studWithoutAngles(runEndPlane, [
+  -studDepth + runEndFootLength + runDoorWidth,
+  0,
+  0
+], [
+  runEndFootLength,
+  studWidth,
+  -studDepth
+], 'runEndFootR'),
+    verticalStudGeo(runEndPlane, [-studDepth, 0, studWidth], 0, studWidth, studDepth, false, 'runEdgeVertStudR', runRoofPitch, heightOfRunEndWall - (studThicknessAtRunAngle * 2)),
+    verticalStudGeo(runEndPlane, [coopLength - studDepth, 0, studWidth], 0, studWidth, studDepth, true, 'runEdgeVertStudL', runRoofPitch, heightOfRunEndWall - (studThicknessAtRunAngle * 2)),
+    pitchedStud2("runEndPitchedStudR1", runEndPlane, [
+  -studDepth,
+  0,
+  heightOfRunEndWall - studThicknessAtRunAngle
+], studWidth, studDepth, runPitchedStudLen, runRoofPitch),
+    pitchedStud2("runEndPitchedStudR2", runEndPlane, [
+  -studDepth,
+  0,
+  heightOfRunEndWall - (studThicknessAtRunAngle * 2)
+], studWidth, studDepth, runPitchedStudLen, runRoofPitch),
+    pitchedStud2("runEndPitchedStudL1", runEndPlane, [
+  -studDepth + coopLength,
+  0,
+  heightOfRunEndWall - studThicknessAtRunAngle
+], studWidth, studDepth, runPitchedStudLen, 180 - runRoofPitch),
+    pitchedStud2("runEndPitchedStudL2", runEndPlane, [
+  -studDepth + coopLength,
+  0,
+  heightOfRunEndWall
+], studWidth, studDepth, runPitchedStudLen, 180 - runRoofPitch),
+    verticalStudGeo(runEndPlane, [coopLength - studDepth, 0, studWidth], runEndFootLength - (studWidth * 2), studWidth, studDepth, true, 'runEndDoorVerticalStudL', runRoofPitch, heightOfRunEndWall - (studThicknessAtRunAngle * 2)),
+    verticalStudGeo(runEndPlane, [-studDepth, 0, studWidth], runEndFootLength - (studWidth * 2), studWidth, studDepth, false, 'runEndDoorVerticalStudR', runRoofPitch, heightOfRunEndWall - (studThicknessAtRunAngle * 2)),
+    verticalStudGeo(runEndPlane, [coopLength - studDepth, 0, studWidth], runEndFootLength - (studWidth * 2) - studDepth, studDepth, studWidth, true, 'runENdDoorVerticalStudL2', runRoofPitch, heightOfRunEndWall - (studThicknessAtRunAngle * 2)),
+    verticalStudGeo(runEndPlane, [-studDepth, 0, studWidth], runEndFootLength - (studWidth * 2) - studDepth, studDepth, studWidth, false, 'runENdDoorVerticalStudR2', runRoofPitch, heightOfRunEndWall - (studThicknessAtRunAngle * 2)),
+    verticalStudGeo(runEndPlane, [coopLength - studDepth, 0, studWidth], studWidth, studDepth, studWidth, true, 'runEndEdgeCornerVerticalStudL', runRoofPitch, heightOfRunEndWall - (studThicknessAtRunAngle * 2)),
+    verticalStudGeo(runEndPlane, [-studDepth, 0, studWidth], studWidth, studDepth, studWidth, false, 'runEndEdgeCornerVerticalStudR', runRoofPitch, heightOfRunEndWall - (studThicknessAtRunAngle * 2)),
+    studWithoutAngles(runEndPlane, [
+  -studDepth + runEndFootLength - studWidth,
+  0,
+  studWidth
+], [
+  studWidth,
+  runDoorHeight - studWidth,
+  -studDepth
+], 'runEndDoorHeaderSupportR'),
+    studWithoutAngles(runEndPlane, [
+  -studDepth + coopLength - runEndFootLength,
+  0,
+  studWidth
+], [
+  studWidth,
+  runDoorHeight - studWidth,
+  -studDepth
+], 'runEndDoorHeaderSupportl'),
+    studWithoutAngles(runEndPlane, [
+  -studDepth + runEndFootLength - studWidth,
+  0,
+  runDoorHeight
+], [
+  runDoorWidth + studWidth * 2,
+  studDepth,
+  -studWidth
+], 'runEndDoorHeader1'),
+    studWithoutAngles(runEndPlane, [
+  -studDepth + runEndFootLength - studWidth,
+  studWidth - studDepth,
+  runDoorHeight
+], [
+  runDoorWidth + studWidth * 2,
+  studDepth,
+  -studWidth
+], 'runEndDoorHeader1'),
+    studWithoutAngles(runEndPlane, [studWidth, 0, studWidth], [
+  runEndFootLength - (studWidth * 3) - (studDepth * 2),
+  studDepth,
+  -studWidth
+], 'runEndBottomRunWallBraceR'),
+    studWithoutAngles(runEndPlane, [studWidth, 0, runHorzBraceHeight], [
+  runEndFootLength - (studWidth * 3) - (studDepth * 2),
+  studDepth,
+  -studWidth
+], 'runEndMiddleRunWallBraceR'),
+    studWithoutAngles(runEndPlane, [
+  runEndFootLength + runDoorWidth + studWidth * 2,
+  0,
+  studWidth
+], [
+  runEndFootLength - (studWidth * 3) - (studDepth * 2),
+  studDepth,
+  -studWidth
+], 'runEndBottomRunWallBraceL'),
+    studWithoutAngles(runEndPlane, [
+  runEndFootLength + runDoorWidth + studWidth * 2,
+  0,
+  runHorzBraceHeight
+], [
+  runEndFootLength - (studWidth * 3) - (studDepth * 2),
+  studDepth,
+  -studWidth
+], 'runEndMiddleRunWallBraceL'),
+    pitchedStud2("runPitchedStudR1", runEndPlane, [
+  studWidth,
+  0,
+  heightOfRunEndWall - (studThicknessAtRunAngle * 2) - studTallSideThicknessAtRunAngle + tan(runRoofPitchR) * (studDepth + studWidth)
+], studDepth, studWidth, runPitchedBraceLen, runRoofPitch),
+    pitchedStud2("runEndPitchedStudL1", runEndPlane, [
+  coopLength - (studDepth * 2) - studWidth,
+  0,
+  heightOfRunEndWall - (studThicknessAtRunAngle * 2) + tan(runRoofPitchR) * (studDepth + studWidth)
+], studDepth, studWidth, runPitchedBraceLen, 180 - runRoofPitch)
+  ]
+  return runEndWallBits
+}
+
+// example, uncomment to check, but should be left comment
+// otherwise causes problem importing elsewhere
+aGroupOfStudForCreatingCutList = runEnd()

--- a/chicken-coop/runWallsAndRoof.kcl
+++ b/chicken-coop/runWallsAndRoof.kcl
@@ -1,0 +1,393 @@
+import variables from "vars.kcl"
+import pitchedStud, pitchedStud2, flatten, verticalStudGeo, studWithoutAngles, concat from "studUtils.kcl"
+import rafterBrace from "rafterBrace.kcl"
+
+slimRender = false
+
+v = variables()
+runRafterCount = v.runRafterCount
+interRafterDistance = v.interRafterDistance
+runEndPlane = v.runEndPlane
+coopLength = v.coopLength
+runDoorWidth = v.runDoorWidth
+studWidth = v.studWidth
+studDepth = v.studDepth
+runRoofPitchR = v.runRoofPitchR
+runRoofPitch = v.runRoofPitch
+heightOfRunEndWall = v.heightOfRunEndWall
+studThicknessAtRunAngle = v.studThicknessAtRunAngle
+runPitchedStudLen = v.runPitchedStudLen
+runDoorHeight = v.runDoorHeight
+runHorzBraceHeight = v.runHorzBraceHeight
+studTallSideThicknessAtRunAngle = v.studTallSideThicknessAtRunAngle
+runSideEaveOverHang = v.runSideEaveOverHang
+rafterCommonZ = v.rafterCommonZ
+runRafterCommonHorizontalDistance = v.runRafterCommonHorizontalDistance
+ridgeWidth = v.ridgeWidth
+runRafterRatio = v.runRafterRatio
+frontRoofAngle = v.frontRoofAngle
+xCoordForRunHorzSupportFront = v.xCoordForRunHorzSupportFront
+xCoordForRunHorzSupportBack = v.xCoordForRunHorzSupportBack
+heightToNotchIntoRafters = v.heightToNotchIntoRafters
+ridgeCenteringX = v.ridgeCenteringX
+ridgeYstartingAtRunEndFacia = v.ridgeYstartingAtRunEndFacia
+runRidgeHeight = v.runRidgeHeight
+ridgeDepth = v.ridgeDepth
+totalLength = v.totalLength
+coopWidth = v.coopWidth
+horzComponentOfRidgeOverCoopRoof = v.horzComponentOfRidgeOverCoopRoof
+horzThicknessOfCoopStud = v.horzThicknessOfCoopStud
+coopRoofPitch = v.coopRoofPitch
+sideEaveOverHang = v.sideEaveOverHang
+coopRoofPitchR = v.coopRoofPitchR
+horizontalLengthAlongRunFromvalleyToTip = v.horizontalLengthAlongRunFromvalleyToTip
+angleFromRunRoofToCoopRoof = v.angleFromRunRoofToCoopRoof
+runRafterBraceLength = v.runRafterBraceLength
+
+battenW = 35
+battenD = 70
+
+fn runRidge() {
+  ridgeLength = totalLength - coopWidth - studWidth + horzComponentOfRidgeOverCoopRoof - horzThicknessOfCoopStud
+  ridgeGeo = startSketchOn({
+         plane = {
+           origin = [
+             ridgeCenteringX,
+             ridgeYstartingAtRunEndFacia,
+             runRidgeHeight
+           ],
+           xAxis = [0, 1, 0],
+           yAxis = [0, 0, 1],
+           zAxis = [1, 0, 0]
+         }
+       })
+    |> startProfileAt([0, 0], %)
+    |> yLine(ridgeDepth, %)
+    |> xLine(-ridgeLength, %)
+    |> angledLineOfYLength({
+         angle = -coopRoofPitch,
+         length = ridgeDepth
+       }, %)
+    |> close(%, $closingSeg)
+    |> extrude(ridgeWidth, %)
+  return {
+    // stud = extrude002,
+    // safeCutLength = safeCutLength,
+    lengthBeforeAngles = min(    segLen(closingSeg), ridgeLength),
+    name = "runRidge",
+    studType = [v.ridgeWidth, "by", v.ridgeDepth],
+    angleRelevantWidth = v.ridgeDepth,
+    endCut1 = 90 - v.coopRoofPitch,
+    endCut2 = 0
+  }
+}
+
+xTallSideThicknessAtCoopAngle = studDepth / sin(coopRoofPitchR)
+xComponentToContinueHeightofRafters = studDepth / tan(coopRoofPitchR)
+coopRoofPlane1 = {
+  plane = {
+    origin = [
+      -studDepth - runSideEaveOverHang + studWidth,
+      sideEaveOverHang + coopWidth + xTallSideThicknessAtCoopAngle - xComponentToContinueHeightofRafters,
+      rafterCommonZ + studTallSideThicknessAtRunAngle
+    ],
+    xAxis = [0, 1, 0],
+    yAxis = [
+      sin(toRadians(90 - runRoofPitch)),
+      0,
+      cos(toRadians(90 - runRoofPitch))
+    ],
+    zAxis = [1, 0, 0]
+  }
+}
+coopRoofPlane2 = {
+  plane = {
+    origin = [
+      studWidth + coopLength,
+      sideEaveOverHang + coopWidth + xTallSideThicknessAtCoopAngle - xComponentToContinueHeightofRafters,
+      rafterCommonZ + studTallSideThicknessAtRunAngle
+    ],
+    xAxis = [0, 1, 0],
+    yAxis = [
+      sin(toRadians(-90 + runRoofPitch)),
+      0,
+      cos(toRadians(-90 + runRoofPitch))
+    ],
+    zAxis = [1, 0, 0]
+  }
+}
+
+fn runValleyFlashingBatten(plane, flip) {
+  multiplier = if flip {
+    1
+  } else {
+    -1
+  }
+
+  runRafterLength = (coopLength / 2 + runSideEaveOverHang - studWidth) / cos(runRoofPitchR)
+  valleyLength = sqrt(pow(horizontalLengthAlongRunFromvalleyToTip, 2) + pow(runRafterLength, 2))
+
+  sketch001 = startSketchOn(plane)
+    |> startProfileAt([0, 0], %)
+    |> angledLine([
+         90 + angleFromRunRoofToCoopRoof,
+         valleyLength
+       ], %, $seg01)
+    |> angledLineOfXLength({ angle = 0, length = studDepth }, %)
+    |> angledLine([segAng(seg01) + 180, segLen(seg01)], %)
+    |> lineTo([profileStartX(%), profileStartY(%)], %)
+    |> close(%)
+    |> extrude(-studWidth * multiplier, %)
+  lengthOfAngleForCut = tan(toDegrees(angleFromRunRoofToCoopRoof)) * studDepth
+  widthOfFlashing = 150
+  lengthOfAngleForFlashing = tan(toDegrees(angleFromRunRoofToCoopRoof)) * widthOfFlashing
+  return [
+    {
+  // stud = extrude002,
+  // safeCutLength = safeCutLength,
+  lengthBeforeAngles = valleyLength - lengthOfAngleForCut,
+  name = "valleyRunStud",
+  studType = [v.studWidth, "by", v.studDepth],
+  angleRelevantWidth = v.studWidth,
+  endCut1 = v.angleFromRunRoofToCoopRoof,
+  endCut2 = v.angleFromRunRoofToCoopRoof
+},
+    {
+  // stud = extrude002,
+  // safeCutLength = safeCutLength,
+  lengthBeforeAngles = valleyLength + lengthOfAngleForFlashing,
+  name = "valleyFlashing",
+  studType = ["valleyFlashing", "by", v.studDepth],
+  angleRelevantWidth = v.studWidth,
+  endCut1 = v.angleFromRunRoofToCoopRoof,
+  endCut2 = v.angleFromRunRoofToCoopRoof
+}
+  ]
+}
+
+fn runBatten(position, flip) {
+  tallSideThicknessAtRunValleyAngle = studDepth / cos(toRadians(angleFromRunRoofToCoopRoof))
+  flipVals = if flip {
+    {
+      plane = coopRoofPlane2,
+      multiplier = -1
+    }
+  } else {
+    {
+      plane = coopRoofPlane1,
+      multiplier = 1
+    }
+  }
+
+  lengthOfBatten = totalLength - coopWidth - studWidth - tallSideThicknessAtRunValleyAngle + tan(toRadians(angleFromRunRoofToCoopRoof)) * position
+  sketch002 = startSketchOn(flipVals.plane)
+    |> startProfileAt([
+         totalLength - coopWidth - studWidth,
+         battenD + position
+       ], %)
+    |> yLine(-battenD, %)
+    |> xLine(-lengthOfBatten, %)
+    |> angledLineOfYLength({
+         length = -battenD,
+         angle = -90 + angleFromRunRoofToCoopRoof
+       }, %)
+    |> close(%)
+    |> extrude(-battenW * flipVals.multiplier, %)
+  return {
+    // stud = extrude002,
+    // safeCutLength = safeCutLength,
+    lengthBeforeAngles = lengthOfBatten,
+    name = "valleyRunStud",
+    studType = [battenD, "by", battenW],
+    angleRelevantWidth = battenD,
+    endCut1 = angleFromRunRoofToCoopRoof,
+    endCut2 = 0
+  }
+}
+
+export fn runWallsAndRoof(plane) {
+  runBits = [
+    // studWithoutAngles(plane, [
+    // v.coopLength - v.studDepth - v.studWidth + v.runSideEaveOverHang,
+    // v.sideEaveOverHang + v.studWidth,
+    // v.bottOfSideEaveHeight
+    // ], [
+    // v.studWidth,
+    // v.studDepth,
+    // v.gutterLineLen
+    // ], 'runFrontGutterLine'),
+    // studWithoutAngles(plane, [
+    // -v.studDepth - v.runSideEaveOverHang,
+    // v.sideEaveOverHang + v.studWidth,
+    // v.bottOfSideEaveHeight
+    // ], [
+    // v.studWidth,
+    // v.studDepth,
+    // v.gutterLineLen
+    // ], 'runBackGutterLine'),
+    pitchedStud2("runEndRafterBack", v.runEndPlane, [
+  v.studWidth - v.studDepth - v.runSideEaveOverHang,
+  v.runEndOverHang,
+  v.rafterCommonZ
+], v.studDepth, v.studWidth, v.runRafterCommonHorizontalDistance / v.runRafterRatio, v.runRoofPitch),
+    pitchedStud2("runEndRafterFront", v.runEndPlane, [
+  -v.studDepth - v.studWidth + v.coopLength + v.runSideEaveOverHang,
+  v.runEndOverHang,
+  v.rafterCommonZ + v.studTallSideThicknessAtRunAngle
+], v.studDepth, v.studWidth, v.runRafterCommonHorizontalDistance / v.runRafterRatio, v.frontRoofAngle),
+    studWithoutAngles(plane, [
+  -v.studDepth,
+  v.sideEaveOverHang + v.studWidth,
+  v.heightToNotchIntoRafters - v.studDepth
+], [
+  v.studWidth,
+  v.studDepth,
+  v.totalLength - v.coopWidth - v.sideEaveOverHang - v.studWidth - v.studDepth
+], 'runHorzTopBack'),
+    studWithoutAngles(plane, [
+  v.coopLength - v.studDepth - v.studWidth,
+  v.sideEaveOverHang + v.studWidth,
+  v.heightToNotchIntoRafters - v.studDepth
+], [
+  v.studWidth,
+  v.studDepth,
+  v.totalLength - v.coopWidth - v.sideEaveOverHang - v.studWidth - v.studDepth
+], 'runHorzTopFront'),
+    studWithoutAngles(plane, [-v.studDepth, 0, 0], [
+  v.studWidth,
+  v.studDepth,
+  v.totalLength - v.coopWidth - v.studDepth
+], 'runHorzBottomBack'),
+    studWithoutAngles(plane, [
+  v.coopLength - v.studDepth - v.studWidth,
+  0,
+  0
+], [
+  v.studWidth,
+  v.studDepth,
+  v.totalLength - v.coopWidth - v.studDepth
+], 'runHorzBottomFront'),
+    studWithoutAngles(plane, [
+  v.xCoordForRunHorzSupportBack,
+  v.studDepth,
+  v.runHorzBraceHeight
+], [
+  v.studWidth,
+  v.studDepth,
+  v.runSupportRemainderLength - v.studWidth
+], 'runHorzMiddleBackFinal'),
+    studWithoutAngles(plane, [
+  v.xCoordForRunHorzSupportFront,
+  v.studDepth,
+  v.runHorzBraceHeight
+], [
+  v.studWidth,
+  v.studDepth,
+  v.runSupportRemainderLength - v.studWidth
+], 'runHorzMiddleFrontFinal'),
+    verticalStudGeo(v.frontPlane, [0, v.coopWidth, v.studDepth], -v.studDepth, v.studDepth, v.studWidth, true, 'verticalRunStudFrontFinal', v.coopRoofPitch, v.coopStartHeight + v.studThicknessAtAngle),
+    verticalStudGeo(v.frontPlane, [
+  0,
+  v.coopWidth,
+  v.heightToNotchIntoRafters - v.studDepth
+], -v.studDepth * 2, v.studDepth, v.studWidth, true, 'verticalRunStudFrontFinal', v.coopRoofPitch, v.coopStartHeight + v.studThicknessAtAngle),
+    verticalStudGeo(v.backPlane, [
+  -v.studDepth + v.studWidth,
+  v.coopWidth,
+  v.studDepth
+], -v.studDepth, v.studDepth, v.studWidth, true, 'verticalRunStudBackFinal', v.coopRoofPitch, v.coopStartHeight + v.studThicknessAtAngle),
+    verticalStudGeo(v.backPlane, [
+  -v.studDepth + v.studWidth,
+  v.coopWidth,
+  v.heightToNotchIntoRafters - v.studDepth
+], -v.studDepth * 2, v.studDepth, v.studWidth, true, 'eaveFillerBack', v.coopRoofPitch, v.coopStartHeight + v.studThicknessAtAngle)
+  ]
+
+  fn rafterAndRunWallSectionPlacer(index) {
+    position = index * interRafterDistance
+    remainder = rem(index, divisor = 2)
+    rafterBits = [
+      pitchedStud2("runRafterFront", runEndPlane, [
+  -studDepth - studWidth + coopLength + runSideEaveOverHang,
+  -position,
+  rafterCommonZ + studTallSideThicknessAtRunAngle
+], studDepth, studWidth, (runRafterCommonHorizontalDistance - (ridgeWidth / 2)) / runRafterRatio, frontRoofAngle),
+      pitchedStud2("runRafterFront", runEndPlane, [
+  -runSideEaveOverHang - studDepth + studWidth,
+  -position,
+  rafterCommonZ
+], studDepth, studWidth, (runRafterCommonHorizontalDistance - (ridgeWidth / 2)) / runRafterRatio, 180 - frontRoofAngle),
+      rafterBrace(runEndPlane, [
+  coopLength / 2 - studDepth,
+  -studWidth * 2 - position,
+  runRidgeHeight + ridgeDepth - (tan(runRoofPitchR) * runRafterBraceLength / 2)
+], runRoofPitch, runRafterBraceLength, studWidth, studDepth)
+    ]
+    shouldAddRunSections = remainder == 0 & index != 0
+    rafterAndRunSections = if shouldAddRunSections & !slimRender {
+      concat(rafterBits, [
+        studWithoutAngles(runEndPlane, [
+  xCoordForRunHorzSupportFront,
+  -position,
+  studDepth
+], [
+  studWidth,
+  heightToNotchIntoRafters - (studDepth * 2),
+  -studDepth
+], 'verticalRunStudFront'),
+        studWithoutAngles(runEndPlane, [
+  xCoordForRunHorzSupportBack,
+  -position,
+  studDepth
+], [
+  studWidth,
+  heightToNotchIntoRafters - (studDepth * 2),
+  -studDepth
+], 'verticalRunStudBack'),
+        studWithoutAngles(runEndPlane, [
+  xCoordForRunHorzSupportBack,
+  -position,
+  runHorzBraceHeight
+], [
+  studWidth,
+  studDepth,
+  interRafterDistance * 2 - studDepth
+], 'runHorzMiddleBack'),
+        studWithoutAngles(runEndPlane, [
+  xCoordForRunHorzSupportFront,
+  -position,
+  runHorzBraceHeight
+], [
+  studWidth,
+  studDepth,
+  interRafterDistance * 2 - studDepth
+], 'runHorzMiddleFront')
+      ])
+    } else {
+      rafterBits
+    }
+    return rafterAndRunSections
+  }
+
+  rafterAndRunSections = flatten(  map([0..runRafterCount], rafterAndRunWallSectionPlacer))
+
+  return flatten([
+    runValleyFlashingBatten(coopRoofPlane1, true),
+    runValleyFlashingBatten(coopRoofPlane2, false),
+    [
+  runBatten(15, false),
+  runBatten(15, true),
+  runBatten(825, false),
+  runBatten(825, true),
+  runBatten(1660, false),
+  runBatten(1660, true),
+  runRidge()
+],
+    runBits,
+    rafterAndRunSections
+  ])
+}
+
+// example, uncomment to check, but should be left comment
+// otherwise causes problem importing elsewhere
+// aGroupOfStudForCreatingCutList = runWallsAndRoof(v.runWallPlane)

--- a/chicken-coop/studUtils.kcl
+++ b/chicken-coop/studUtils.kcl
@@ -1,0 +1,215 @@
+import variables from "vars.kcl"
+
+v = variables()
+
+export fn concat(arr1, arr2) {
+  fn pusher(item, prevArr) {
+    return push(prevArr, item)
+  }
+  return reduce(arr2, arr1, pusher)
+}
+
+export fn flatten(arr) {
+  fn flatMapReducer(innerArr, prevFlattenArr) {
+    return concat(prevFlattenArr, innerArr)
+  }
+  return reduce(arr, [], flatMapReducer)
+}
+
+export fn studWithoutAngles(plane, origin, sizes, name) {
+  sketch004 = startSketchOn({
+         plane = {
+           origin = [
+             plane.plane.origin[0] + origin[0],
+             plane.plane.origin[1] + origin[1],
+             plane.plane.origin[2] + origin[2]
+           ],
+           xAxis = plane.plane.xAxis,
+           yAxis = plane.plane.yAxis,
+           zAxis = plane.plane.zAxis
+         }
+       })
+    |> startProfileAt([0, 0], %)
+    |> angledLine([0, sizes[0]], %, $rectangleSegmentA002)
+    |> angledLine([
+         segAng(rectangleSegmentA002) - 90,
+         -sizes[1]
+       ], %, $rectangleSegmentB002)
+    |> angledLine([
+         segAng(rectangleSegmentA002),
+         -segLen(rectangleSegmentA002)
+       ], %, $rectangleSegmentC002)
+    |> lineTo([profileStartX(%), profileStartY(%)], %)
+    |> close(%)
+  extrude001 = extrude(sizes[2], sketch004)
+  return {
+    // stud = extrude001,
+    // safeCutLength = max(sizes[0], sizes[1], sizes[2]),
+    lengthBeforeAngles = max(abs(sizes[0]), abs(sizes[1]), abs(sizes[2])),
+    name = name,
+    studType = [v.studWidth, "by", v.studDepth],
+    endCut1 = 0,
+    endCut2 = 0,
+    // this function always returns 0 degree cuts so angleRelevantWidth doesn't matter
+    angleRelevantWidth = v.studDepth
+  }
+}
+
+// deprecated should port to use pitchStud2 and delete this
+export fn pitchedStud(plane, shouldReverse) {
+  coopHightMinusStud = v.coopStartHeight - sin(toRadians(v.coopRoofPitch))
+  changeValues = if shouldReverse {
+    {
+      multiplier = -1,
+      startX = v.coopWidth
+    }
+  } else {
+    { multiplier = 1, startX = 0 }
+  }
+  sketch003 = startSketchOn(plane)
+    |> startProfileAt([
+         changeValues.startX,
+         coopHightMinusStud
+       ], %)
+    |> angledLineOfXLength([
+         v.coopRoofPitch * changeValues.multiplier,
+         v.coopWidthHalf * changeValues.multiplier
+       ], %, $seg02)
+    |> angledLineThatIntersects({
+         angle = 90,
+         offset = v.studWidth * changeValues.multiplier,
+         intersectTag = seg02
+       }, %)
+    |> angledLine([segAng(seg02) + 180, segLen(seg02)], %)
+    |> lineTo([profileStartX(%), profileStartY(%)], %)
+    |> close(%)
+  extrude002 = extrude(-v.studDepth, sketch003)
+  safeCutLength = v.coopWidthHalf / cos(toRadians(v.coopRoofPitch)) + v.studWidth * tan(toRadians(v.coopRoofPitch))
+  lengthBeforeAngles = v.coopWidthHalf / cos(toRadians(v.coopRoofPitch)) - (v.studWidth * tan(toRadians(v.coopRoofPitch)))
+  return {
+    // stud = extrude002,
+    // safeCutLength = safeCutLength,
+    lengthBeforeAngles = lengthBeforeAngles,
+    name = "backPitchedStud",
+    studType = [v.studWidth, "by", v.studDepth],
+    angleRelevantWidth = v.studWidth,
+    endCut1 = v.coopRoofPitch,
+    endCut2 = v.coopRoofPitch
+  }
+}
+export fn pitchedStud2(name, plane, origin, height, depth, length, angle) {
+  coopHightMinusStud = v.coopStartHeight - sin(toRadians(v.coopRoofPitch))
+  sketch003 = startSketchOn({
+         plane = {
+           origin = [
+             plane.plane.origin[0] + origin[0],
+             plane.plane.origin[1] + origin[1],
+             plane.plane.origin[2] + origin[2]
+           ],
+           xAxis = plane.plane.xAxis,
+           yAxis = plane.plane.yAxis,
+           zAxis = plane.plane.zAxis
+         }
+       })
+    |> startProfileAt([0, 0], %)
+    |> angledLine([angle, length], %, $seg02)
+    |> angledLineThatIntersects({
+         angle = 90,
+         offset = height,
+         intersectTag = seg02
+       }, %)
+    |> angledLine([segAng(seg02) + 180, segLen(seg02)], %)
+    |> lineTo([profileStartX(%), profileStartY(%)], %)
+    |> close(%)
+  extrude002 = extrude(-depth, sketch003)
+  // this safeCutLength was always wrong, copy paste from pitchedStud
+  // safeCutLength = coopWidthHalf / cos(toRadians(angle)) + height * tan(toRadians(angle))
+  lengthBeforeAngles = length - abs(height * tan(toRadians(angle)))
+  displayAngle = if angle > 90 {
+    180 - angle
+  } else {
+    angle
+  }
+  return {
+    // stud = extrude002,
+    // safeCutLength = safeCutLength,
+    lengthBeforeAngles = lengthBeforeAngles,
+    name = name,
+    studType = [
+      min(height, depth),
+      "by",
+      max(height, depth)
+    ],
+    angleRelevantWidth = height,
+    endCut1 = displayAngle,
+    endCut2 = displayAngle
+  }
+}
+
+export fn verticalStudGeo(plane, origin, position, width, depth, flip, name, angle, startHeight) {
+  studLengthShortSide = startHeight + position * tan(toRadians(angle)) - origin[2]
+  flipMultiple = if flip {
+    -1
+  } else {
+    1
+  }
+  sketch004 = startSketchOn({
+         plane = {
+           origin = [
+             plane.plane.origin[0] + origin[0],
+             plane.plane.origin[1] + origin[1],
+             plane.plane.origin[2] + origin[2]
+           ],
+           xAxis = plane.plane.xAxis,
+           yAxis = plane.plane.yAxis,
+           zAxis = plane.plane.zAxis
+         }
+       })
+    |> startProfileAt([position * flipMultiple, 0], %)
+    |> yLine(studLengthShortSide, %)
+    |> angledLineOfXLength({
+         angle = angle * flipMultiple,
+         length = width * flipMultiple
+       }, %)
+    |> yLineTo(profileStartY(%), %)
+    |> lineTo([profileStartX(%), profileStartY(%)], %)
+    |> close(%)
+    |> extrude(-depth, %)
+  lengthBeforeAngles = if width < 0 {
+    studLengthShortSide - abs(tan(toRadians(angle)) * width)
+  } else {
+    studLengthShortSide
+  }
+  return {
+    // safeCutLength = studLengthShortSide + tan(toRadians(angle)) * width,
+    lengthBeforeAngles = lengthBeforeAngles,
+    // stud = extrude(-depth, sketch004),
+    studType = [
+      min(width, depth),
+      "by",
+      max(width, depth)
+    ],
+    endCut1 = 0,
+    endCut2 = angle,
+    angleRelevantWidth = width,
+    name = name
+  }
+}
+
+// examples to check things work as expected
+// they should be commented out normally though as they cause problems when importing otherwise
+// pitchedStud(v.frontPlane, false)
+// pitchedStud(v.frontPlane, true)
+
+
+// studWithoutAngles(v.frontPlane, [0, 0, 0], [v.coopFrameLength, v.studWidth, -v.studDepth], 'outsideFrameBase')
+
+
+// pitchedStud2("backEndRafterR", v.frontPlane, [
+// -v.backEaveOverHang,
+// 450,
+// 300 + 60
+// ], v.studDepth, v.studWidth, 20, 30)
+
+
+// verticalStudGeo(v.frontPlane, [0, 0, v.studWidth], v.studWidth, v.studDepth, v.studWidth, false, 'frontCornerStudL', v.coopRoofPitch, v.coopStartHeight)

--- a/chicken-coop/vars.kcl
+++ b/chicken-coop/vars.kcl
@@ -1,0 +1,249 @@
+export fn variables() {
+  coopLength = 2950 // 2260 theirs
+  coopStorageLength = 1050
+  coopWidth = 1500
+  totalLength = 7500 // includes the coop so run length = totalLength - coopWidth
+  studWidth = 35
+  coopRoofPitch = 45 // 45 theirs
+  runRoofPitch = 23 // 23 theirs
+  // runRoofPitch = 30 // 23 theirs
+  // runRoofPitch = toDegrees(
+  // atan(
+  // (coopWidth/2 * tan(toRadians(coopRoofPitch))) / (coopLength/2)
+  // )
+  // )
+  nestingRoofPitch = runRoofPitch // 23 theirs
+  studDepth = 90
+  runDoorWidth = 960
+  runDoorHeight = 1730
+  coopStartHeight = 1550
+  interStudDistance = 600
+  coopDoorWidth = 750
+  coopDoorHeight = 1750
+  nestingBoxHeight = 550
+  windowHeight = 420
+  windowWidth = 400 // 400
+  windowCount = 2
+  chickenDoorHeight = 475
+  frontEaveOverHang = 400
+  backEaveOverHang = 160 + 35
+  sideEaveOverHang = 200
+  runSideEaveOverHang = 150
+  runEndOverHang = 200
+  ridgeWidth = 35
+  ridgeDepth = 140
+  runHorzBraceHeight = 550
+  foundationStudOverlap = 200
+  interRafterDistance = 600
+  nestingBoxDepth = 450
+  runRafterBraceLength = 1600
+
+  // calc values
+  coopFrameLength = coopLength - (studDepth * 2)
+  coopWidthHalf = coopWidth / 2
+  coopFrontFootWidth = (coopWidth - coopDoorWidth) / 2
+  studCountBetweenSideAndDoor = floor((coopFrontFootWidth - (studWidth * 4)) / interStudDistance)
+  studCountOverDoor = floor((coopDoorWidth / 2 - (studWidth * 2)) / interStudDistance)
+  studCountBack = floor((coopWidthHalf - studWidth) / interStudDistance)
+  coopRoofPitchR = toRadians(coopRoofPitch)
+  runRoofPitchR = toRadians(runRoofPitch)
+  nestingRoofPitchR = toRadians(nestingRoofPitch)
+  sideEaveOverHangXComponent = tan(coopRoofPitchR) * sideEaveOverHang
+  runSideEaveVerticalComponent = tan(runRoofPitchR) * runSideEaveOverHang
+  studTallSideThicknessAtRunAngle = studDepth / cos(runRoofPitchR)
+  studThicknessAtAngle = studWidth / cos(coopRoofPitchR)
+  studThicknessAtRunAngle = studWidth / cos(runRoofPitchR)
+  coopFrameHeight = coopStartHeight + studThicknessAtAngle + tan(coopRoofPitchR) * studWidth
+  // run and ridge math
+  ridgeCenteringX = coopLength / 2 - studDepth - (ridgeWidth / 2)
+  ridgeYstartingAtRunEndFacia = totalLength + runEndOverHang - studWidth
+  heightToBottomOfTheRunEave = coopStartHeight + studThicknessAtAngle - sideEaveOverHangXComponent
+  runSideEaveOverHandYComponent = tan(runRoofPitchR) * runSideEaveOverHang
+  runStudThicknessAtAngle = studWidth * tan(runRoofPitchR)
+  heightOfRunEndWall = heightToBottomOfTheRunEave + runSideEaveOverHandYComponent - runStudThicknessAtAngle
+  topOfRidgeAtBottomOfEave = heightToBottomOfTheRunEave - ridgeDepth
+  topOfRunRidgeAtBottomOfRafterPeak = topOfRidgeAtBottomOfEave + tan(runRoofPitchR) * (coopLength / 2 - studWidth + runSideEaveOverHang)
+  topOfRunRudgeAtTopOfRafterPeak = topOfRunRidgeAtBottomOfRafterPeak + studTallSideThicknessAtRunAngle
+  runRidgeHeight = topOfRunRudgeAtTopOfRafterPeak - (tan(runRoofPitchR) * ridgeWidth / 2)
+  heightDeltaOfRidgeToRoof = runRidgeHeight - topOfRidgeAtBottomOfEave
+  horzComponentOfRidgeOverCoopRoof = heightDeltaOfRidgeToRoof / tan(coopRoofPitchR)
+  horzThicknessOfCoopStud = studDepth / sin(coopRoofPitchR)
+  heightToNotchIntoRafters = heightToBottomOfTheRunEave + tan(runRoofPitchR) * runSideEaveOverHang
+
+  // other run variables
+  studTallSideThicknessAtAngle = studDepth / cos(toRadians(coopRoofPitch))
+  leftRafterAngle = coopRoofPitch
+  rightRafterAngle = 180 - coopRoofPitch
+  leftRafterY = -sideEaveOverHang
+  rightRafterY = sideEaveOverHang + coopWidth
+  rafterCommonZ = coopStartHeight + studThicknessAtAngle - (sideEaveOverHang * tan(toRadians(coopRoofPitch)))
+  rafterRatioForAngle = cos(coopRoofPitchR)
+  rafterCommonHorzLength = coopWidthHalf + sideEaveOverHang - (ridgeWidth / 2)
+  rafterLength = rafterCommonHorzLength / rafterRatioForAngle
+  bottOfSideEaveHeight = coopStartHeight - (tan(coopRoofPitchR) * sideEaveOverHang) + studThicknessAtAngle
+
+  // more run stuff I think
+  gutterLineLen = totalLength - coopWidth - sideEaveOverHang - studWidth + runEndOverHang
+  backRoofAngle = runRoofPitch
+  frontRoofAngle = 180 - runRoofPitch
+  runRafterRatio = cos(runRoofPitchR)
+  runRafterCommonHorizontalDistance = coopLength / 2 - studWidth + runSideEaveOverHang
+  runPitchedStudLen = coopLength / 2 / cos(runRoofPitchR)
+  xCoordForRunHorzSupportFront = coopLength - studDepth - studWidth
+  xCoordForRunHorzSupportBack = -studDepth
+  distanceToDitributeRaftersIn = totalLength - coopWidth - runSideEaveOverHang
+  runRafterCount = floor(distanceToDitributeRaftersIn / interRafterDistance)
+  runSupportRemainderLength = rem(distanceToDitributeRaftersIn, divisor = interRafterDistance * 2)
+
+  runHypotenuse = coopLength / 2 / cos(runRoofPitchR)
+  coopHypotenuse = coopWidth / 2 / cos(coopRoofPitchR)
+  runHeight = tan(runRoofPitchR) * coopLength / 2
+  horizontalLengthAlongRunFromvalleyToTip = runHeight / tan(coopRoofPitchR)
+  angleFromRunRoofToCoopRoofR = atan(horizontalLengthAlongRunFromvalleyToTip / runHypotenuse)
+  angleFromRunRoofToCoopRoof = toDegrees(angleFromRunRoofToCoopRoofR)
+  valleyFlashingLength = sqrt(pow(horizontalLengthAlongRunFromvalleyToTip, 2) + pow(runHypotenuse, 2))
+  angleFromCoopRoofToRunRoofR = acos(coopHypotenuse/valleyFlashingLength)
+  angleFromCoopRoofToRunRoof = toDegrees(angleFromCoopRoofToRunRoofR)
+
+  outsideWallPlane = {
+    plane = {
+      origin = [0, studDepth, 0],
+      xAxis = [1, 0, 0],
+      yAxis = [0, 0, 1],
+      zAxis = [0, 1, 0]
+    }
+  }
+  runWallPlane = {
+    plane = {
+      origin = [0, coopWidth, 0],
+      xAxis = [1, 0, 0],
+      yAxis = [0, 0, 1],
+      zAxis = [0, 1, 0]
+    }
+  }
+  runEndPlane = {
+    plane = {
+      origin = [0, totalLength, 0],
+      xAxis = [1, 0, 0],
+      yAxis = [0, 0, 1],
+      zAxis = [0, 1, 0]
+    }
+  }
+  runEndPlane2 = {
+    plane = {
+      origin = [0, totalLength, 0],
+      xAxis = [1, 0, 0],
+      yAxis = [0, 0, 1],
+      zAxis = [0, 1, 0]
+    }
+  }
+  frontPlane = {
+    plane = {
+      origin = [coopLength - studDepth, 0, 0],
+      xAxis = [0, 1, 0],
+      yAxis = [0, 0, 1],
+      zAxis = [1, 0, 0]
+    }
+  }
+  backPlane = {
+    plane = {
+      origin = [0, 0, 0],
+      xAxis = [0, 1, 0],
+      yAxis = [0, 0, 1],
+      zAxis = [1, 0, 0]
+    }
+  }
+  return {
+    coopLength = coopLength,
+    coopStorageLength = coopStorageLength,
+    coopWidth = coopWidth,
+    totalLength = totalLength,
+    studWidth = studWidth,
+    coopRoofPitch = coopRoofPitch,
+    runRoofPitch = runRoofPitch,
+    nestingRoofPitch = nestingRoofPitch,
+    studDepth = studDepth,
+    runDoorWidth = runDoorWidth,
+    runDoorHeight = runDoorHeight,
+    coopStartHeight = coopStartHeight,
+    interStudDistance = interStudDistance,
+    coopDoorWidth = coopDoorWidth,
+    coopDoorHeight = coopDoorHeight,
+    nestingBoxHeight = nestingBoxHeight,
+    windowHeight = windowHeight,
+    windowWidth = windowWidth,
+    windowCount = windowCount,
+    chickenDoorHeight = chickenDoorHeight,
+    frontEaveOverHang = frontEaveOverHang,
+    backEaveOverHang = backEaveOverHang,
+    sideEaveOverHang = sideEaveOverHang,
+    runSideEaveOverHang = runSideEaveOverHang,
+    runEndOverHang = runEndOverHang,
+    ridgeWidth = ridgeWidth,
+    ridgeDepth = ridgeDepth,
+    runHorzBraceHeight = runHorzBraceHeight,
+    foundationStudOverlap = foundationStudOverlap,
+    interRafterDistance = interRafterDistance,
+    nestingBoxDepth = nestingBoxDepth,
+    runRafterBraceLength = runRafterBraceLength,
+    coopFrameLength = coopFrameLength,
+    coopFrameHeight = coopFrameHeight,
+    coopWidthHalf = coopWidthHalf,
+    coopFrontFootWidth = coopFrontFootWidth,
+    studCountBetweenSideAndDoor = studCountBetweenSideAndDoor,
+    studCountOverDoor = studCountOverDoor,
+    studCountBack = studCountBack,
+    coopRoofPitchR = coopRoofPitchR,
+    runRoofPitchR = runRoofPitchR,
+    nestingRoofPitchR = nestingRoofPitchR,
+    sideEaveOverHangXComponent = sideEaveOverHangXComponent,
+    runSideEaveVerticalComponent = runSideEaveVerticalComponent,
+    studTallSideThicknessAtRunAngle = studTallSideThicknessAtRunAngle,
+    studThicknessAtAngle = studThicknessAtAngle,
+    studThicknessAtRunAngle = studThicknessAtRunAngle,
+    studTallSideThicknessAtAngle = studTallSideThicknessAtAngle,
+    leftRafterAngle = leftRafterAngle,
+    rightRafterAngle = rightRafterAngle,
+    leftRafterY = leftRafterY,
+    rightRafterY = rightRafterY,
+    rafterCommonZ = rafterCommonZ,
+    rafterRatioForAngle = rafterRatioForAngle,
+    rafterCommonHorzLength = rafterCommonHorzLength,
+    rafterLength = rafterLength,
+    bottOfSideEaveHeight = bottOfSideEaveHeight,
+    gutterLineLen = gutterLineLen,
+    backRoofAngle = backRoofAngle,
+    frontRoofAngle = frontRoofAngle,
+    runRafterRatio = runRafterRatio,
+    runRafterCommonHorizontalDistance = runRafterCommonHorizontalDistance,
+    runPitchedStudLen = runPitchedStudLen,
+    xCoordForRunHorzSupportFront = xCoordForRunHorzSupportFront,
+    xCoordForRunHorzSupportBack = xCoordForRunHorzSupportBack,
+    distanceToDitributeRaftersIn = distanceToDitributeRaftersIn,
+    runRafterCount = runRafterCount,
+    runSupportRemainderLength = runSupportRemainderLength,
+    ridgeCenteringX = ridgeCenteringX,
+    ridgeYstartingAtRunEndFacia = ridgeYstartingAtRunEndFacia,
+    heightToBottomOfTheRunEave = heightToBottomOfTheRunEave,
+    runSideEaveOverHandYComponent = runSideEaveOverHandYComponent,
+    runStudThicknessAtAngle = runStudThicknessAtAngle,
+    heightOfRunEndWall = heightOfRunEndWall,
+    topOfRidgeAtBottomOfEave = topOfRidgeAtBottomOfEave,
+    topOfRunRidgeAtBottomOfRafterPeak = topOfRunRidgeAtBottomOfRafterPeak,
+    topOfRunRudgeAtTopOfRafterPeak = topOfRunRudgeAtTopOfRafterPeak,
+    runRidgeHeight = runRidgeHeight,
+    heightDeltaOfRidgeToRoof = heightDeltaOfRidgeToRoof,
+    horzComponentOfRidgeOverCoopRoof = horzComponentOfRidgeOverCoopRoof,
+    horzThicknessOfCoopStud = horzThicknessOfCoopStud,
+    heightToNotchIntoRafters = heightToNotchIntoRafters,
+    angleFromRunRoofToCoopRoof = angleFromRunRoofToCoopRoof,
+    angleFromCoopRoofToRunRoof = angleFromCoopRoofToRunRoof,
+    horizontalLengthAlongRunFromvalleyToTip = horizontalLengthAlongRunFromvalleyToTip,
+    outsideWallPlane = outsideWallPlane,
+    runWallPlane = runWallPlane,
+    runEndPlane = runEndPlane,
+    runEndPlane2 = runEndPlane2,
+    frontPlane = frontPlane,
+    backPlane = backPlane
+  }
+}


### PR DESCRIPTION
Some images first than details below

![image](https://github.com/user-attachments/assets/41093534-feb6-40f1-9707-869e47b94e2f)

![image](https://github.com/user-attachments/assets/3f219aed-bc7e-42c4-b19a-a8366fd859da)

![image](https://github.com/user-attachments/assets/b314ddd2-48eb-46d1-988c-c94d8ed40a15)

![image](https://github.com/user-attachments/assets/2d831f3a-3cdf-4551-b7b7-9a599015b4ea)

![image](https://github.com/user-attachments/assets/1651f153-b546-43df-bdf9-f9b9a7163490)

![image](https://github.com/user-attachments/assets/0451e3de-cdb8-4b59-afba-aa6172d32cb7)

![image](https://github.com/user-attachments/assets/c30560aa-adc2-4496-8558-6da8db2ed3ef)


- It's a chicken coop, it's about 3x7.5m big about 2.5m tall at the highest point.
- I think what makes this most different to our other samples is that this is mostly a big assembly, the geometry of each stud is very simple, but there's about 200 of them.
- The main output of the kcl is a BOM of sorts, the geometry is only useful as a visual aid during development, I'm not exporting the geometry to do anything useful with it.
- I very much ran into the issue of too many function definitions causing the modeling app to slow down, this mean I stopped at the frame (didn't model the cladding or roof sheets) and that I wasn't able to add all the abstractions I wanted.
- The core concept of having a stud function that adds the stud to the scene but also returns a "cut-item" (the studs length and the cut angles) worked, and from it I was able to create a cut list
- The cut list code was written in javascript, since I was already hitting the "too many functions" problem with kcl, I too the escape hatch of taking the data from kcl and doing more work with it in javascript (TODO link to javascript)
- I was however able to make a `concat` and `flatmap` functions in KCL by abstracting `reduce`, might be worth adding these into rust, but was cool to see it's doable.
- Every single stud get it's length and is placed with variables/math/trig, but I can imagine some useful raycast/intersection util functions that would let me query the existing geometry in order to drive lengths and what not instead of labouring so much on math.
- Because the "too many function" problem, I would work on individual files, and would bring them together in `assembly.kcl` only when I needed to see it all together. This worked but the `Cannot send modeling commands while importing.` was a real PITA because I would have to comment things out to get the assembly working again, and then uncomment when working again in the sub-file.
- I don't have an example handy, but I noticed that errors in files that you're important are "silent". We don't have UI or similar to tell the user there's a problem in the imported file.
- at the time of writing I'm waiting for the roof sheet and cladding to arrive so I can finish it.

Here's the well loved cut list that I printed and poured over (it's 5 pages). I checked everything because I was terrified there would be a bug, causing bad cuts wasting material and therefore money, but it was perfect, the only mistakes were my implementing the cut list where I had cut things wrong, but the list it's self was perfect.
![image](https://github.com/user-attachments/assets/89afaab6-743f-4015-a933-44c811f40cbd)

Of course it's parametric, so here's the coop I made
![image](https://github.com/user-attachments/assets/15124839-5b5f-4fba-b34d-82f65653735e)

But here it is again with a steper pitched roof for the coop, A wider coop and shorter run, and studs that are more American 2x4"s instead of 35x90mm
![image](https://github.com/user-attachments/assets/37d26e0f-1e9b-4c16-bcb3-3df64978c837)



Misc

errors in kcl appear on the feature tree icon??
![image](https://github.com/user-attachments/assets/c850d1cd-9fe8-48d1-bf98-dc059d6dd94f)
formatting of arrays that wrap can get really gnarly (see the definition of `coopFront` for an example)
![image](https://github.com/user-attachments/assets/914600ec-8b5d-4c34-826d-8b1b3550ac85)

