### PR TITLE
Kwargs: chamfer and fillet

### DIFF
--- a/80-20-rail/main.kcl
+++ b/80-20-rail/main.kcl
@@ -197,7 +197,7 @@ fn rail8020(originStart, railHeight, railLength) {
          radius = .205 * railHeight / 2
        }, %), %)
     |> extrude(length = railLength)
-    |> fillet({
+    |> fillet(
          radius = 0.06,
          tags = [
            getNextAdjacentEdge(edge3),
@@ -217,8 +217,8 @@ fn rail8020(originStart, railHeight, railLength) {
            getNextAdjacentEdge(edge29),
            getNextAdjacentEdge(edge30)
          ]
-       }, %)
-    |> fillet({
+       )
+    |> fillet(
          radius = 0.03,
          tags = [
            getNextAdjacentEdge(edge1),
@@ -238,7 +238,7 @@ fn rail8020(originStart, railHeight, railLength) {
            getNextAdjacentEdge(edge31),
            getNextAdjacentEdge(edge32)
          ]
-       }, %)
+       )
   return sketch001
 }
 

--- a/bracket/main.kcl
+++ b/bracket/main.kcl
@@ -49,13 +49,13 @@ bracketLeg1Sketch = startSketchOn('XY')
 
 // Extrude the leg 2 bracket sketch
 bracketLeg1Extrude = extrude(bracketLeg1Sketch, length = thickness)
-  |> fillet({
+  |> fillet(
        radius = extFilletRadius,
        tags = [
          getNextAdjacentEdge(fillet1),
          getNextAdjacentEdge(fillet2)
        ]
-     }, %)
+     )
 
 // Sketch the fillet arc
 filletSketch = startSketchOn('XZ')
@@ -104,10 +104,10 @@ bracketLeg2Sketch = startSketchOn(customPlane)
 
 // Extrude the second leg
 bracketLeg2Extrude = extrude(bracketLeg2Sketch, length = -thickness)
-  |> fillet({
+  |> fillet(
        radius = extFilletRadius,
        tags = [
          getNextAdjacentEdge(fillet3),
          getNextAdjacentEdge(fillet4)
        ]
-     }, %)
+     )

--- a/enclosure/main.kcl
+++ b/enclosure/main.kcl
@@ -25,7 +25,7 @@ sketch001 = startSketchOn('XY')
   |> line(endAbsolute = [profileStartX(%), profileStartY(%)], tag = $rectangleSegmentD001)
   |> close()
 extrude001 = extrude(sketch001, length = height)
-  |> fillet({
+  |> fillet(
        radius = wallThickness * 4,
        tags = [
          getNextAdjacentEdge(rectangleSegmentA001),
@@ -33,7 +33,7 @@ extrude001 = extrude(sketch001, length = height)
          getNextAdjacentEdge(rectangleSegmentC001),
          getNextAdjacentEdge(rectangleSegmentD001)
        ]
-     }, %)
+     )
 
   // Apply a shell to the enclosure base to create the internal storage
   |> shell(
@@ -129,7 +129,7 @@ sketch003 = startSketchOn('XY')
        radius = holeDia
      }, %), %)
 extrude003 = extrude(sketch003, length = wallThickness)
-  |> fillet({
+  |> fillet(
        radius = wallThickness * 4,
        tags = [
          getNextAdjacentEdge(rectangleSegmentA002),
@@ -137,7 +137,7 @@ extrude003 = extrude(sketch003, length = wallThickness)
          getNextAdjacentEdge(rectangleSegmentC002),
          getNextAdjacentEdge(rectangleSegmentD002)
        ]
-     }, %)
+     )
 
 // Define lid inner and sealing surfaces
 sketch004 = startSketchOn(extrude003, 'END')
@@ -185,7 +185,7 @@ sketch004 = startSketchOn(extrude003, 'END')
        radius = holeDia + wallThickness
      }, %), %)
 extrude004 = extrude(sketch004, length = wallThickness)
-  |> fillet({
+  |> fillet(
        radius = wallThickness * 3,
        tags = [
          getNextAdjacentEdge(rectangleSegmentA003),
@@ -193,4 +193,4 @@ extrude004 = extrude(sketch004, length = wallThickness)
          getNextAdjacentEdge(rectangleSegmentC003),
          getNextAdjacentEdge(rectangleSegmentD003)
        ]
-     }, %)
+     )

--- a/exhaust-manifold/main.kcl
+++ b/exhaust-manifold/main.kcl
@@ -136,17 +136,17 @@ flangeSketch = startSketchOn('XY')
 
   // Extrude the flange and fillet the edges
   |> extrude(length = plateHeight)
-  |> fillet({
+  |> fillet(
        radius = 1.5,
        tags = [
          getNextAdjacentEdge(seg04),
          getNextAdjacentEdge(seg07)
        ]
-     }, %)
-  |> fillet({
+     )
+  |> fillet(
        radius = .25,
        tags = [
          getNextAdjacentEdge(seg03),
          getNextAdjacentEdge(seg08)
        ]
-     }, %)
+     )

--- a/focusrite-scarlett-mounting-bracket/main.kcl
+++ b/focusrite-scarlett-mounting-bracket/main.kcl
@@ -55,7 +55,7 @@ fn bracketSketch(w, d, t) {
 bs = bracketSketch(width, depth, thk)
 bracketBody = bs
   |> extrude(length = length + 2 * thk)
-  |> fillet({
+  |> fillet(
        radius = radius,
        tags = [
          getPreviousAdjacentEdge(bs.tags.edge7),
@@ -63,7 +63,7 @@ bracketBody = bs
          getPreviousAdjacentEdge(bs.tags.edge3),
          getPreviousAdjacentEdge(bs.tags.edge6)
        ]
-     }, %)
+     )
 
 // define the tab plane
 tabPlane = {
@@ -90,13 +90,13 @@ tabsR = startSketchOn(tabPlane)
        radius = holeDiam / 2
      }, %), %)
   |> extrude(length = -tabThk)
-  |> fillet({
+  |> fillet(
        radius = holeDiam / 2,
        tags = [
          getNextAdjacentEdge(edge11),
          getNextAdjacentEdge(edge12)
        ]
-     }, %)
+     )
   |> patternLinear3d(
        axis = [0, -1, 0],
        instances = 2,
@@ -118,13 +118,13 @@ tabsL = startSketchOn(tabPlane)
        radius = holeDiam / 2
      }, %), %)
   |> extrude(length = -tabThk)
-  |> fillet({
+  |> fillet(
        radius = holeDiam / 2,
        tags = [
          getNextAdjacentEdge(edge21),
          getNextAdjacentEdge(edge22)
        ]
-     }, %)
+     )
   |> patternLinear3d(
        axis = [0, -1, 0],
        instances = 2,

--- a/food-service-spatula/main.kcl
+++ b/food-service-spatula/main.kcl
@@ -77,13 +77,14 @@ spatulaProfile = flipperProfile
 flipper = extrude(spatulaProfile, length = flipperThickness)
 
 // fillet the edges of the flipper
-fillet({
+fillet(
+  flipper,
   radius = flipperFilletRadius,
   tags = [
     getNextAdjacentEdge(backEdge),
     getPreviousAdjacentEdge(backEdge)
   ]
-}, flipper)
+)
 
 // create a sketch on the "XZ" plane offset by half the thickness
 sketch001 = startSketchOn(offsetPlane("XZ", offset = -handleWidth / 2))
@@ -102,13 +103,14 @@ handleProfile = startProfileAt([0.0, flipperThickness], sketch001)
 handle = extrude(handleProfile, length = handleWidth)
 
 // fillet the bend of the spatula handle
-fillet({
+fillet(
+  handle,
   radius = 4,
   tags = [
     getNextAdjacentEdge(handleBottomEdge),
     getNextAdjacentEdge(handleTopEdge)
   ]
-}, handle)
+)
 
 // define a plane which is at the end of the handle
 handlePlane = {

--- a/mounting-plate/main.kcl
+++ b/mounting-plate/main.kcl
@@ -62,7 +62,7 @@ part = rs
        radius = centerHoleDiameter
      }, %), %)
   |> extrude(length = plateThickness)
-  |> fillet({
+  |> fillet(
        radius = filletRadius,
        tags = [
          getPreviousAdjacentEdge(rs.tags.edge1),
@@ -70,4 +70,4 @@ part = rs
          getPreviousAdjacentEdge(rs.tags.edge3),
          getPreviousAdjacentEdge(rs.tags.edge4)
        ]
-     }, %)
+     )

--- a/multi-axis-robot/robot-arm-base.kcl
+++ b/multi-axis-robot/robot-arm-base.kcl
@@ -23,7 +23,7 @@ sketch001 = startSketchOn('XY')
   |> line(endAbsolute = [profileStartX(%), profileStartY(%)], tag = $rectangleSegmentD001)
   |> close()
 extrude001 = extrude(sketch001, length = basePlateThickness)
-  |> chamfer({
+  |> chamfer(
        length = baseChamfer,
        tags = [
          getNextAdjacentEdge(rectangleSegmentA001),
@@ -31,16 +31,16 @@ extrude001 = extrude(sketch001, length = basePlateThickness)
          getNextAdjacentEdge(rectangleSegmentC001),
          getNextAdjacentEdge(rectangleSegmentD001)
        ]
-     }, %)
+     )
 
 // Base Motor for actuating first joint
 sketch002 = startSketchOn(extrude001, 'END')
   |> circle({ center = [0, 0], radius = 4 }, %, $referenceEdge)
 extrude002 = extrude(sketch002, length = baseHeight - basePlateThickness - 1.5)
-  |> fillet({
+  |> fillet(
        radius = 0.1,
        tags = [getOppositeEdge(referenceEdge)]
-     }, %)
+     )
 sketch003 = startSketchOn(extrude002, 'END')
   |> circle({ center = [0, 0], radius = 0.5 }, %)
 extrude003 = extrude(sketch003, length = 1)

--- a/multi-axis-robot/robot-arm-j2.kcl
+++ b/multi-axis-robot/robot-arm-j2.kcl
@@ -35,10 +35,10 @@ sketch012 = startSketchOn(extrude011, 'START')
   |> circle({ center = [-1.75, 8], radius = 1.9 }, %, $referenceEdge4)
 
 extrude012 = extrude(sketch012, length = 0.15)
-  |> fillet({
+  |> fillet(
        radius = 0.1,
        tags = [getOppositeEdge(referenceEdge4)]
-     }, %)
+     )
 sketch013 = startSketchOn(extrude011, 'START')
   |> circle({
        center = [
@@ -49,10 +49,10 @@ sketch013 = startSketchOn(extrude011, 'START')
      }, %, $referenceEdge5)
 
 extrude013 = extrude(sketch013, length = 1)
-  |> fillet({
+  |> fillet(
        radius = 0.1,
        tags = [getOppositeEdge(referenceEdge5)]
-     }, %)
+     )
 
 // Draw Bolt Patterns on J2 Robot Arm
 sketch014 = startSketchOn(extrude012, 'END')

--- a/multi-axis-robot/robot-arm-j3.kcl
+++ b/multi-axis-robot/robot-arm-j3.kcl
@@ -41,10 +41,10 @@ sketch018 = startSketchOn(extrude017, 'END')
      }, %, $referenceEdge6)
 
 extrude018 = extrude(sketch018, length = 0.15)
-  |> fillet({
+  |> fillet(
        radius = 0.1,
        tags = [getOppositeEdge(referenceEdge6)]
-     }, %)
+     )
 
 // Draw Bolt Pattern on J3 Robot Arm
 sketch019 = startSketchOn(extrude018, 'END')

--- a/multi-axis-robot/robot-rotating-base.kcl
+++ b/multi-axis-robot/robot-rotating-base.kcl
@@ -11,10 +11,10 @@ import axisJ1, baseHeight, plane001, plane002 from "globals.kcl"
 sketch005 = startSketchOn(plane001)
   |> circle({ center = [0, 0], radius = 3.9 }, %, $referenceEdge1)
 extrude005 = extrude(sketch005, length = 1.5 - 0.1)
-  |> fillet({
+  |> fillet(
        radius = 0.1,
        tags = [getOppositeEdge(referenceEdge1)]
-     }, %)
+     )
   |> appearance(color = "#4f7d54", metalness = 90, roughness = 90)
 
 sketch006 = startSketchOn(plane002)
@@ -40,10 +40,10 @@ sketch007 = startSketchOn(extrude006, 'END')
        radius = 2.75
      }, %, $referenceEdge2)
 extrude007 = extrude(sketch007, length = 1.5)
-  |> fillet({
+  |> fillet(
        radius = 0.1,
        tags = [getOppositeEdge(referenceEdge2)]
-     }, %)
+     )
 
 // Draw Bolt Pattern on Rotating Base
 sketch008 = startSketchOn(extrude007, 'END')
@@ -74,10 +74,10 @@ sketch009 = startSketchOn(extrude007, 'END')
        radius = 0.5
      }, %, $referenceEdge3)
 extrude009 = extrude(sketch009, length = 0.15)
-  |> fillet({
+  |> fillet(
        radius = 0.1,
        tags = [getOppositeEdge(referenceEdge3)]
-     }, %)
+     )
   |> appearance(color = "#4f7d54", metalness = 90, roughness = 90)
 
 sketch010 = startSketchOn(plane002)

--- a/sheet-metal-bracket/main.kcl
+++ b/sheet-metal-bracket/main.kcl
@@ -30,38 +30,38 @@ baseExtrusion = startSketchOn('-XZ')
   |> line(end = [0, -hatHeight], tag = $e11)
   |> close(tag = $e12)
   |> extrude(length = hatWidth)
-  |> fillet({
+  |> fillet(
        radius = bendRad,
        tags = [getNextAdjacentEdge(e2)]
-     }, %)
-  |> fillet({
+     )
+  |> fillet(
        radius = outsideBendRad,
        tags = [getNextAdjacentEdge(e3)]
-     }, %)
-  |> fillet({
+     )
+  |> fillet(
        radius = outsideBendRad,
        tags = [getNextAdjacentEdge(e4)]
-     }, %)
-  |> fillet({
+     )
+  |> fillet(
        radius = bendRad,
        tags = [getNextAdjacentEdge(e5)]
-     }, %)
-  |> fillet({
+     )
+  |> fillet(
        radius = outsideBendRad,
        tags = [getNextAdjacentEdge(e8)]
-     }, %)
-  |> fillet({
+     )
+  |> fillet(
        radius = bendRad,
        tags = [getNextAdjacentEdge(e9)]
-     }, %)
-  |> fillet({
+     )
+  |> fillet(
        radius = bendRad,
        tags = [getNextAdjacentEdge(e10)]
-     }, %)
-  |> fillet({
+     )
+  |> fillet(
        radius = outsideBendRad,
        tags = [getNextAdjacentEdge(e11)]
-     }, %)
+     )
 
 // Define the flanges and place the bolt holes
 flange1 = startSketchOn('XY')
@@ -79,13 +79,13 @@ flange1 = startSketchOn('XY')
        radius = boltSize
      }, %), %)
   |> extrude(length = thickness)
-  |> fillet({
+  |> fillet(
        radius = 0.5,
        tags = [
          getNextAdjacentEdge(e13),
          getNextAdjacentEdge(e14)
        ]
-     }, %)
+     )
 
 flange2 = startSketchOn('XY')
   |> startProfileAt([-6, 0], %)
@@ -102,10 +102,10 @@ flange2 = startSketchOn('XY')
        radius = boltSize
      }, %), %)
   |> extrude(length = thickness)
-  |> fillet({
+  |> fillet(
        radius = 0.25,
        tags = [
          getNextAdjacentEdge(e15),
          getNextAdjacentEdge(e16)
        ]
-     }, %)
+     )

--- a/walkie-talkie/body.kcl
+++ b/walkie-talkie/body.kcl
@@ -15,7 +15,7 @@ bodySketch = startSketchOn('XZ')
   |> xLine(-width, %, $chamfer3)
   |> close(tag = $chamfer4)
 bodyExtrude = extrude(bodySketch, length = thickness)
-  |> chamfer({
+  |> chamfer(
        length = chamferLength,
        tags = [
          getNextAdjacentEdge(chamfer1),
@@ -23,7 +23,7 @@ bodyExtrude = extrude(bodySketch, length = thickness)
          getNextAdjacentEdge(chamfer3),
          getNextAdjacentEdge(chamfer4)
        ]
-     }, %)
+     )
 
 // Define the offset for the indentation
 sketch002 = startSketchOn(bodyExtrude, 'END')

--- a/walkie-talkie/button.kcl
+++ b/walkie-talkie/button.kcl
@@ -25,13 +25,13 @@ export fn button(origin, rotation, plane) {
        }, %)
     |> close()
   buttonExtrude = extrude(buttonSketch, length = buttonThickness)
-    |> chamfer({
+    |> chamfer(
          length = .050,
          tags = [
            getNextAdjacentEdge(tag1),
            getNextAdjacentEdge(tag2)
          ]
-       }, %)
+       )
      |> appearance(color = "#ff0000")
 
   return buttonExtrude

--- a/walkie-talkie/talk-button.kcl
+++ b/walkie-talkie/talk-button.kcl
@@ -34,7 +34,7 @@ talkButtonSketch = startSketchOn(talkButtonPlane)
 
 // Create the talk button and apply fillets
 extrude(talkButtonSketch, length = talkButtonHeight)
-  |> fillet({
+  |> fillet(
        radius = 0.050,
        tags = [
          getNextAdjacentEdge(tag1),
@@ -42,5 +42,5 @@ extrude(talkButtonSketch, length = talkButtonHeight)
          getNextAdjacentEdge(tag3),
          getNextAdjacentEdge(tag4)
        ]
-     }, %)
+     )
   |> appearance(color = '#D0FF01', metalness = 90, roughness = 90)


### PR DESCRIPTION
Migrate `fillet` and `chamfer` calls to use keyword arguments.