### PR TITLE
Fix to not rely on import side-effects

### DIFF
--- a/car-wheel-assembly/brake-caliper.kcl
+++ b/car-wheel-assembly/brake-caliper.kcl
@@ -92,5 +92,5 @@ brakeCaliperSketch = startSketchOn(brakeCaliperPlane)
   |> close()
 
 // Revolve the brake caliper sketch
-export brakeCaliper = revolve({ axis = "Y", angle = -70 }, brakeCaliperSketch)
+revolve({ axis = "Y", angle = -70 }, brakeCaliperSketch)
   |> appearance(color = "#c82d2d", metalness = 90, roughness = 90)

--- a/car-wheel-assembly/car-tire.kcl
+++ b/car-wheel-assembly/car-tire.kcl
@@ -40,5 +40,5 @@ tireSketch = startSketchOn("XY")
   |> close()
 
 // Revolve the sketch to create the tire
-export carTire = revolve({ axis = "Y" }, tireSketch)
+revolve({ axis = "Y" }, tireSketch)
   |> appearance(color = "#0f0f0f", roughness = 80)

--- a/car-wheel-assembly/car-wheel.kcl
+++ b/car-wheel-assembly/car-wheel.kcl
@@ -155,7 +155,7 @@ spoke(spokeGap, spokeAngle, spokeThickness)
 spoke(-spokeGap, -spokeAngle, -spokeThickness)
 
 // Define and revolve wheel exterior
-wheelOuterRevolve = startSketchOn('XY')
+startSketchOn('XY')
   |> startProfileAt([
        wheelDiameter / 2,
        -wheelWidth + backSpacing + offset

--- a/car-wheel-assembly/lug-nut.kcl
+++ b/car-wheel-assembly/lug-nut.kcl
@@ -39,4 +39,4 @@ fn lug(plane, length, diameter) {
   return lugSketch
 }
 
-export lugNut = lug(customPlane, lugLength, lugDiameter)
+lug(customPlane, lugLength, lugDiameter)

--- a/car-wheel-assembly/main.kcl
+++ b/car-wheel-assembly/main.kcl
@@ -6,9 +6,9 @@
 
 import 'car-wheel.kcl' as carWheel 
 import 'car-rotor.kcl' as carRotor
-import brakeCaliper from "brake-caliper.kcl"
-import lugNut from 'lug-nut.kcl'
-import carTire from 'car-tire.kcl'
+import "brake-caliper.kcl" as brakeCaliper
+import 'lug-nut.kcl' as lugNut
+import 'car-tire.kcl' as carTire
 import lugCount from 'globals.kcl'
 
 carRotor
@@ -21,4 +21,5 @@ lugNut
      instances = lugCount,
      rotateDuplicates = false
    )
-  
+brakeCaliper
+carTire


### PR DESCRIPTION
I know we agreed to merge into `next`, but I think `main` is broken. This shouldn't make it worse.